### PR TITLE
feat: fastify v4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,4 @@ jobs:
     with:
       lint: true
       license-check: true
+      node-versions: '["18", "20", "22"]'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # @fastify/otel
 
+[![CI](https://github.com/fastify/otel/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/fastify/otel/actions/workflows/ci.yml)
+[![NPM version](https://img.shields.io/npm/v/@fastify/otel.svg?style=flat)](https://www.npmjs.com/package/@fastify/otel)
+[![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)
+
 OpenTelemetry auto-instrumentation library.
 
 ## Install

--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ const {
 } = require('@opentelemetry/semantic-conventions')
 const { InstrumentationBase } = require('@opentelemetry/instrumentation')
 
-const fp = require('fastify-plugin')
-
 const {
   version: PACKAGE_VERSION,
   name: PACKAGE_NAME
@@ -64,10 +62,14 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
   plugin () {
     const instrumentation = this
 
-    return fp(FastifyInstrumentationPlugin, {
+    FastifyInstrumentationPlugin[Symbol.for('skip-override')] = true
+    FastifyInstrumentationPlugin[Symbol.for('fastify.display-name')] = '@fastify/otel'
+    FastifyInstrumentationPlugin[Symbol.for('plugin-meta')] = {
       fastify: SUPPORTED_VERSIONS,
       name: '@fastify/otel',
-    })
+    }
+
+    return FastifyInstrumentationPlugin
 
     function FastifyInstrumentationPlugin (instance, opts, done) {
       const addHookOriginal = instance.addHook.bind(instance)

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const {
 } = require('./package.json')
 
 // Constants
-const SUPPORTED_VERSIONS = '>=5.0.0 <6'
+const SUPPORTED_VERSIONS = '>=4.0.0 <6'
 const FASTIFY_HOOKS = [
   'onRequest',
   'preParsing',

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "test": "npm run test:unit && npm run test:typescript",
+    "test": "npm run test:all && npm run test:typescript",
     "test:unit": "c8 --100 node --test",
+    "test:all": "npm run test:v4 && npm run test:v5",
+    "test:v4": "FASTIFY_VERSION=fastifyv4 npm run test:unit",
+    "test:v5": "FASTIFY_VERSION=fastify npm run test:unit",
     "test:coverage": "c8 node --test && c8 report --reporter=html",
     "test:typescript": "tsd"
   },
@@ -53,6 +56,7 @@
     "c8": "^10.1.2",
     "eslint": "^9.16.0",
     "fastify": "^5.1.0",
+    "fastifyv4": "npm:fastify@^4.0.0",
     "neostandard": "^0.12.0",
     "tsd": "^0.31.0"
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test": "npm run test:all && npm run test:typescript",
     "test:unit": "c8 --100 node --test",
     "test:all": "npm run test:v4 && npm run test:v5",
-    "test:v4": "FASTIFY_VERSION=fastifyv4 npm run test:unit",
-    "test:v5": "FASTIFY_VERSION=fastify npm run test:unit",
+    "test:v4": "cross-env FASTIFY_VERSION=fastifyv4 npm run test:unit",
+    "test:v5": "cross-env FASTIFY_VERSION=fastify npm run test:unit",
     "test:coverage": "c8 node --test && c8 report --reporter=html",
     "test:typescript": "tsd"
   },
@@ -54,6 +54,7 @@
     "@opentelemetry/sdk-trace-node": "^1.29.0",
     "@types/node": "^22.0.0",
     "c8": "^10.1.2",
+    "cross-env": "^7.0.3",
     "eslint": "^9.16.0",
     "fastify": "^5.1.0",
     "fastifyv4": "npm:fastify@^4.0.0",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.29.0",
     "@opentelemetry/instrumentation": "^0.57.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
-    "fastify-plugin": "^5.0.1"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0"

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test, describe } = require('node:test')
+const assert = require('assert')
 const Fastify = require(process.env.FASTIFY_VERSION || 'fastify')
 
 const { InstrumentationBase } = require('@opentelemetry/instrumentation')
@@ -9,20 +10,20 @@ const FastifyInstrumentation = require('..')
 
 describe('Interface', () => {
   test('should exports support', t => {
-    t.assert.equal(FastifyInstrumentation.name, 'FastifyOtelInstrumentation')
-    t.assert.equal(
+    assert.equal(FastifyInstrumentation.name, 'FastifyOtelInstrumentation')
+    assert.equal(
       FastifyInstrumentation.default.name,
       'FastifyOtelInstrumentation'
     )
-    t.assert.equal(
+    assert.equal(
       FastifyInstrumentation.FastifyOtelInstrumentation.name,
       'FastifyOtelInstrumentation'
     )
-    t.assert.strictEqual(
+    assert.strictEqual(
       Object.getPrototypeOf(FastifyInstrumentation),
       InstrumentationBase
     )
-    t.assert.strictEqual(new FastifyInstrumentation({ servername: 'test' }).servername, 'test')
+    assert.strictEqual(new FastifyInstrumentation({ servername: 'test' }).servername, 'test')
   })
 
   test('FastifyInstrumentation#plugin should return a valid Fastify Plugin', async t => {
@@ -30,8 +31,8 @@ describe('Interface', () => {
     const instrumentation = new FastifyInstrumentation()
     const plugin = instrumentation.plugin()
 
-    t.assert.equal(typeof plugin, 'function')
-    t.assert.equal(plugin.length, 3)
+    assert.equal(typeof plugin, 'function')
+    assert.equal(plugin.length, 3)
 
     app.register(plugin)
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const Fastify = require(process.env.FASTIFY_VERSION || 'fastify')
+
+const { InstrumentationBase } = require('@opentelemetry/instrumentation')
+
+const FastifyInstrumentation = require('..')
+
+describe('Interface', () => {
+  test('should exports support', t => {
+    t.assert.equal(FastifyInstrumentation.name, 'FastifyOtelInstrumentation')
+    t.assert.equal(
+      FastifyInstrumentation.default.name,
+      'FastifyOtelInstrumentation'
+    )
+    t.assert.equal(
+      FastifyInstrumentation.FastifyOtelInstrumentation.name,
+      'FastifyOtelInstrumentation'
+    )
+    t.assert.strictEqual(
+      Object.getPrototypeOf(FastifyInstrumentation),
+      InstrumentationBase
+    )
+    t.assert.strictEqual(new FastifyInstrumentation({ servername: 'test' }).servername, 'test')
+  })
+
+  test('FastifyInstrumentation#plugin should return a valid Fastify Plugin', async t => {
+    const app = Fastify()
+    const instrumentation = new FastifyInstrumentation()
+    const plugin = instrumentation.plugin()
+
+    t.assert.equal(typeof plugin, 'function')
+    t.assert.equal(plugin.length, 3)
+
+    app.register(plugin)
+
+    await app.ready()
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const {
   test,
   describe,
@@ -6,8 +8,8 @@ const {
   afterEach,
   beforeEach
 } = require('node:test')
+const Fastify = require(process.env.FASTIFY_VERSION || 'fastify')
 
-const { InstrumentationBase } = require('@opentelemetry/instrumentation')
 const {
   AsyncHooksContextManager
 } = require('@opentelemetry/context-async-hooks')
@@ -20,41 +22,7 @@ const { context, SpanStatusCode } = require('@opentelemetry/api')
 
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http')
 
-const Fastify = require('fastify')
-
 const FastifyInstrumentation = require('..')
-
-describe('Interface', () => {
-  test('should exports support', t => {
-    t.assert.equal(FastifyInstrumentation.name, 'FastifyOtelInstrumentation')
-    t.assert.equal(
-      FastifyInstrumentation.default.name,
-      'FastifyOtelInstrumentation'
-    )
-    t.assert.equal(
-      FastifyInstrumentation.FastifyOtelInstrumentation.name,
-      'FastifyOtelInstrumentation'
-    )
-    t.assert.strictEqual(
-      Object.getPrototypeOf(FastifyInstrumentation),
-      InstrumentationBase
-    )
-    t.assert.strictEqual(new FastifyInstrumentation({ servername: 'test' }).servername, 'test')
-  })
-
-  test('FastifyInstrumentation#plugin should return a valid Fastify Plugin', async t => {
-    const app = Fastify()
-    const instrumentation = new FastifyInstrumentation()
-    const plugin = instrumentation.plugin()
-
-    t.assert.equal(typeof plugin, 'function')
-    t.assert.equal(plugin.length, 3)
-
-    app.register(plugin)
-
-    await app.ready()
-  })
-})
 
 describe('FastifyInstrumentation', () => {
   const httpInstrumentation = new HttpInstrumentation()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,7 @@ const {
   afterEach,
   beforeEach
 } = require('node:test')
+const assert = require('node:assert')
 const Fastify = require(process.env.FASTIFY_VERSION || 'fastify')
 
 const {
@@ -60,8 +61,6 @@ describe('FastifyInstrumentation', () => {
 
       instrumentation.disable()
 
-      t.plan(3)
-
       const response = await app.inject({
         method: 'GET',
         url: '/'
@@ -71,9 +70,9 @@ describe('FastifyInstrumentation', () => {
         .getFinishedSpans()
         .find(span => span.instrumentationLibrary.name === '@fastify/otel')
 
-      t.assert.ok(spans == null)
-      t.assert.equal(response.statusCode, 200)
-      t.assert.equal(response.body, 'hello world')
+      assert.ok(spans == null)
+      assert.equal(response.statusCode, 200)
+      assert.equal(response.body, 'hello world')
     })
   })
 
@@ -114,24 +113,23 @@ describe('FastifyInstrumentation', () => {
 
       const [end, start] = spans
 
-      t.plan(5)
-      t.assert.equal(spans.length, 2)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 2)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
-      t.assert.deepStrictEqual(end.attributes, {
+      assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
         'service.name': 'fastify',
         'hook.callback.name': 'anonymous'
       })
-      t.assert.equal(response.status, 200)
-      t.assert.equal(await response.text(), 'hello world')
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'hello world')
     })
 
     test('should create named span (simple case)', async t => {
@@ -158,25 +156,24 @@ describe('FastifyInstrumentation', () => {
 
       const [end, start] = spans
 
-      t.plan(6)
-      t.assert.equal(spans.length, 2)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 2)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
-      t.assert.deepStrictEqual(end.attributes, {
+      assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
         'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
-      t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(response.status, 200)
-      t.assert.equal(await response.text(), 'hello world')
+      assert.equal(end.parentSpanId, start.spanContext().spanId)
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'hello world')
     })
 
     test('should create span for different hooks', async t => {
@@ -219,53 +216,52 @@ describe('FastifyInstrumentation', () => {
 
       const [preHandler, onReq2, onReq1, end, start] = spans
 
-      t.plan(10)
-      t.assert.equal(spans.length, 5)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 5)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
-      t.assert.deepStrictEqual(onReq1.attributes, {
+      assert.deepStrictEqual(onReq1.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'onRequest1',
         'hook.name': 'fastify -> @fastify/otel - route -> onRequest',
         'http.route': '/',
         'service.name': 'fastify',
       })
-      t.assert.deepStrictEqual(onReq2.attributes, {
+      assert.deepStrictEqual(onReq2.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'anonymous',
         'hook.name': 'fastify -> @fastify/otel - route -> onRequest',
         'http.route': '/',
         'service.name': 'fastify',
       })
-      t.assert.deepStrictEqual(preHandler.attributes, {
+      assert.deepStrictEqual(preHandler.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'preHandler',
         'hook.name': 'fastify -> @fastify/otel - route -> preHandler',
         'http.route': '/',
         'service.name': 'fastify',
       })
-      t.assert.deepStrictEqual(end.attributes, {
+      assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
         'hook.callback.name': 'helloworld',
         'service.name': 'fastify',
       })
-      t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(response.status, 200)
-      t.assert.equal(await response.text(), 'hello world')
+      assert.equal(end.parentSpanId, start.spanContext().spanId)
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'hello world')
     })
 
     test('should create span for different hooks (patched)', async t => {
@@ -309,45 +305,44 @@ describe('FastifyInstrumentation', () => {
 
       const [preValidation, end, start, onReq1] = spans
 
-      t.plan(9)
-      t.assert.equal(spans.length, 4)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 4)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
         'service.name': 'fastify',
         'http.response.status_code': 200
       })
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
         'service.name': 'fastify',
         'http.response.status_code': 200
       })
-      t.assert.deepStrictEqual(onReq1.attributes, {
+      assert.deepStrictEqual(onReq1.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'onSend',
         'hook.name': 'fastify -> @fastify/otel - route -> onSend',
         'service.name': 'fastify',
         'http.route': '/'
       })
-      t.assert.deepStrictEqual(preValidation.attributes, {
+      assert.deepStrictEqual(preValidation.attributes, {
         'fastify.type': 'hook',
         'hook.callback.name': 'preValidation',
         'service.name': 'fastify',
         'hook.name': 'fastify -> @fastify/otel - preValidation'
       })
-      t.assert.deepStrictEqual(end.attributes, {
+      assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
         'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
-      t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(response.status, 200)
-      t.assert.equal(await response.text(), 'hello world')
+      assert.equal(end.parentSpanId, start.spanContext().spanId)
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'hello world')
     })
 
     test('should create span for different hooks (error scenario)', async t => {
@@ -378,24 +373,23 @@ describe('FastifyInstrumentation', () => {
 
       const [preHandler, start] = spans
 
-      t.plan(6)
-      t.assert.equal(spans.length, 2)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 2)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
         'service.name': 'fastify',
         'http.response.status_code': 500
       })
-      t.assert.deepStrictEqual(preHandler.attributes, {
+      assert.deepStrictEqual(preHandler.attributes, {
         'fastify.type': 'hook',
         'hook.callback.name': 'anonymous',
         'service.name': 'fastify',
         'hook.name': 'fastify -> @fastify/otel - preHandler'
       })
-      t.assert.equal(preHandler.status.code, SpanStatusCode.ERROR)
-      t.assert.equal(preHandler.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(response.status, 500)
+      assert.equal(preHandler.status.code, SpanStatusCode.ERROR)
+      assert.equal(preHandler.parentSpanId, start.spanContext().spanId)
+      assert.equal(response.status, 500)
     })
 
     test('should create named span (404)', async t => {
@@ -423,10 +417,9 @@ describe('FastifyInstrumentation', () => {
 
       const [start] = spans
 
-      t.plan(3)
-      t.assert.equal(response.status, 404)
-      t.assert.equal(spans.length, 1)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(response.status, 404)
+      assert.equal(spans.length, 1)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
@@ -464,17 +457,16 @@ describe('FastifyInstrumentation', () => {
 
       const [start, fof] = spans
 
-      t.plan(4)
-      t.assert.equal(response.status, 404)
-      t.assert.equal(spans.length, 2)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(response.status, 404)
+      assert.equal(spans.length, 2)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
         'service.name': 'fastify',
         'http.response.status_code': 404
       })
-      t.assert.deepStrictEqual(fof.attributes, {
+      assert.deepStrictEqual(fof.attributes, {
         'hook.name': 'fastify -> @fastify/otel - not-found-handler',
         'fastify.type': 'hook',
         'service.name': 'fastify',
@@ -534,39 +526,38 @@ describe('FastifyInstrumentation', () => {
 
       const [preHandler, preValidation, start, fof] = spans
 
-      t.plan(9)
-      t.assert.equal(response.status, 404)
-      t.assert.equal(spans.length, 4)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(response.status, 404)
+      assert.equal(spans.length, 4)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
         'service.name': 'fastify',
         'http.response.status_code': 404
       })
-      t.assert.deepStrictEqual(preHandler.attributes, {
+      assert.deepStrictEqual(preHandler.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preHandler',
         'fastify.type': 'hook',
         'service.name': 'fastify',
         'hook.callback.name': 'preHandler'
       })
-      t.assert.deepStrictEqual(preValidation.attributes, {
+      assert.deepStrictEqual(preValidation.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preValidation',
         'fastify.type': 'hook',
         'service.name': 'fastify',
         'hook.callback.name': 'preValidation'
       })
-      t.assert.deepStrictEqual(fof.attributes, {
+      assert.deepStrictEqual(fof.attributes, {
         'hook.name': 'fastify -> @fastify/otel - not-found-handler',
         'fastify.type': 'hook',
         'service.name': 'fastify',
         'hook.callback.name': 'notFoundHandler'
       })
-      t.assert.equal(fof.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(preValidation.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(preHandler.parentSpanId, start.spanContext().spanId)
+      assert.equal(fof.parentSpanId, start.spanContext().spanId)
+      assert.equal(preValidation.parentSpanId, start.spanContext().spanId)
+      assert.equal(preHandler.parentSpanId, start.spanContext().spanId)
     })
 
     test('should create named span (404 - customized with hooks)', async t => {
@@ -621,39 +612,38 @@ describe('FastifyInstrumentation', () => {
 
       const [preHandler, preValidation, start, fof] = spans
 
-      t.plan(9)
-      t.assert.equal(response.status, 404)
-      t.assert.equal(spans.length, 4)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(response.status, 404)
+      assert.equal(spans.length, 4)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
         'service.name': 'fastify',
         'http.response.status_code': 404
       })
-      t.assert.deepStrictEqual(preHandler.attributes, {
+      assert.deepStrictEqual(preHandler.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preHandler',
         'fastify.type': 'hook',
         'service.name': 'fastify',
         'hook.callback.name': 'preHandler'
       })
-      t.assert.deepStrictEqual(preValidation.attributes, {
+      assert.deepStrictEqual(preValidation.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preValidation',
         'fastify.type': 'hook',
         'service.name': 'fastify',
         'hook.callback.name': 'preValidation'
       })
-      t.assert.deepStrictEqual(fof.attributes, {
+      assert.deepStrictEqual(fof.attributes, {
         'hook.name': 'fastify -> @fastify/otel - not-found-handler',
         'fastify.type': 'hook',
         'service.name': 'fastify',
         'hook.callback.name': 'notFoundHandler'
       })
-      t.assert.equal(fof.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(preValidation.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(preHandler.parentSpanId, start.spanContext().spanId)
+      assert.equal(fof.parentSpanId, start.spanContext().spanId)
+      assert.equal(preValidation.parentSpanId, start.spanContext().spanId)
+      assert.equal(preHandler.parentSpanId, start.spanContext().spanId)
     })
 
     test('should end spans upon error', async t => {
@@ -688,25 +678,24 @@ describe('FastifyInstrumentation', () => {
 
       const [end, start] = spans
 
-      t.plan(6)
-      t.assert.equal(spans.length, 2)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 2)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
         'service.name': 'fastify',
         'http.response.status_code': 500
       })
-      t.assert.deepStrictEqual(end.attributes, {
+      assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
         'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
-      t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(response.status, 500)
-      t.assert.deepStrictEqual(await response.json(), {
+      assert.equal(end.parentSpanId, start.spanContext().spanId)
+      assert.equal(response.status, 500)
+      assert.deepStrictEqual(await response.json(), {
         statusCode: 500,
         error: 'Internal Server Error',
         message: 'error'
@@ -748,32 +737,31 @@ describe('FastifyInstrumentation', () => {
 
       const [end, start, error] = spans
 
-      t.plan(7)
-      t.assert.equal(spans.length, 3)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 3)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
         'service.name': 'fastify',
         'http.response.status_code': 500
       })
-      t.assert.deepStrictEqual(error.attributes, {
+      assert.deepStrictEqual(error.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'decorated',
         'hook.name': 'fastify -> @fastify/otel - route -> onError',
         'http.route': '/',
         'service.name': 'fastify',
       })
-      t.assert.deepStrictEqual(end.attributes, {
+      assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
         'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
-      t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(response.status, 500)
-      t.assert.deepStrictEqual(await response.json(), {
+      assert.equal(end.parentSpanId, start.spanContext().spanId)
+      assert.equal(response.status, 500)
+      assert.deepStrictEqual(await response.json(), {
         statusCode: 500,
         error: 'Internal Server Error',
         message: 'error'
@@ -820,39 +808,38 @@ describe('FastifyInstrumentation', () => {
 
       const [end, start, error2, error] = spans
 
-      t.plan(8)
-      t.assert.equal(spans.length, 4)
-      t.assert.deepStrictEqual(start.attributes, {
+      assert.equal(spans.length, 4)
+      assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
         'service.name': 'fastify',
         'http.response.status_code': 500
       })
-      t.assert.deepStrictEqual(error.attributes, {
+      assert.deepStrictEqual(error.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'decorated',
         'hook.name': 'fastify -> @fastify/otel - route -> onError',
         'service.name': 'fastify',
         'http.route': '/'
       })
-      t.assert.deepStrictEqual(error2.attributes, {
+      assert.deepStrictEqual(error2.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'decorated2',
         'hook.name': 'fastify -> @fastify/otel - route -> onError',
         'service.name': 'fastify',
         'http.route': '/'
       })
-      t.assert.deepStrictEqual(end.attributes, {
+      assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
         'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
-      t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-      t.assert.equal(response.status, 500)
-      t.assert.deepStrictEqual(await response.json(), {
+      assert.equal(end.parentSpanId, start.spanContext().spanId)
+      assert.equal(response.status, 500)
+      assert.deepStrictEqual(await response.json(), {
         statusCode: 500,
         error: 'Internal Server Error',
         message: 'error'
@@ -887,8 +874,6 @@ describe('FastifyInstrumentation', () => {
 
         instrumentation.disable()
 
-        t.plan(3)
-
         const response = await app.inject({
           method: 'GET',
           url: '/'
@@ -898,9 +883,9 @@ describe('FastifyInstrumentation', () => {
           .getFinishedSpans()
           .find(span => span.instrumentationLibrary.name === '@fastify/otel')
 
-        t.assert.ok(spans == null)
-        t.assert.equal(response.statusCode, 200)
-        t.assert.equal(response.body, 'hello world')
+        assert.ok(spans == null)
+        assert.equal(response.statusCode, 200)
+        assert.equal(response.body, 'hello world')
       })
     })
 
@@ -944,24 +929,23 @@ describe('FastifyInstrumentation', () => {
 
         const [end, start] = spans
 
-        t.plan(5)
-        t.assert.equal(spans.length, 2)
-        t.assert.deepStrictEqual(start.attributes, {
+        assert.equal(spans.length, 2)
+        assert.deepStrictEqual(start.attributes, {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
           'service.name': 'fastify',
           'http.response.status_code': 200
         })
-        t.assert.deepStrictEqual(end.attributes, {
+        assert.deepStrictEqual(end.attributes, {
           'hook.name': 'plugin - route-handler',
           'fastify.type': 'request-handler',
           'service.name': 'fastify',
           'http.route': '/',
           'hook.callback.name': 'anonymous'
         })
-        t.assert.equal(response.status, 200)
-        t.assert.equal(await response.text(), 'hello world')
+        assert.equal(response.status, 200)
+        assert.equal(await response.text(), 'hello world')
       })
 
       test('should create named span (simple case)', async t => {
@@ -990,25 +974,24 @@ describe('FastifyInstrumentation', () => {
 
         const [end, start] = spans
 
-        t.plan(6)
-        t.assert.equal(spans.length, 2)
-        t.assert.deepStrictEqual(start.attributes, {
+        assert.equal(spans.length, 2)
+        assert.deepStrictEqual(start.attributes, {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
           'service.name': 'fastify',
           'http.response.status_code': 200
         })
-        t.assert.deepStrictEqual(end.attributes, {
+        assert.deepStrictEqual(end.attributes, {
           'hook.name': 'nested -> @fastify/otel - route-handler',
           'fastify.type': 'request-handler',
           'http.route': '/',
           'service.name': 'fastify',
           'hook.callback.name': 'helloworld'
         })
-        t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-        t.assert.equal(response.status, 200)
-        t.assert.equal(await response.text(), 'hello world')
+        assert.equal(end.parentSpanId, start.spanContext().spanId)
+        assert.equal(response.status, 200)
+        assert.equal(await response.text(), 'hello world')
       })
 
       test('should create span for different hooks (patched)', async t => {
@@ -1056,45 +1039,44 @@ describe('FastifyInstrumentation', () => {
 
         const [preValidation, end, start, onReq1] = spans
 
-        t.plan(9)
-        t.assert.equal(spans.length, 4)
-        t.assert.deepStrictEqual(start.attributes, {
+        assert.equal(spans.length, 4)
+        assert.deepStrictEqual(start.attributes, {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
           'service.name': 'fastify',
           'http.response.status_code': 200
         })
-        t.assert.deepStrictEqual(start.attributes, {
+        assert.deepStrictEqual(start.attributes, {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
           'service.name': 'fastify',
           'http.response.status_code': 200
         })
-        t.assert.deepStrictEqual(onReq1.attributes, {
+        assert.deepStrictEqual(onReq1.attributes, {
           'fastify.type': 'route-hook',
           'hook.callback.name': 'onSend',
           'hook.name': 'nested - route -> onSend',
           'service.name': 'fastify',
           'http.route': '/'
         })
-        t.assert.deepStrictEqual(preValidation.attributes, {
+        assert.deepStrictEqual(preValidation.attributes, {
           'fastify.type': 'hook',
           'hook.callback.name': 'anonymous',
           'service.name': 'fastify',
           'hook.name': 'fastify -> @fastify/otel - preValidation'
         })
-        t.assert.deepStrictEqual(end.attributes, {
+        assert.deepStrictEqual(end.attributes, {
           'hook.name': 'nested - route-handler',
           'fastify.type': 'request-handler',
           'http.route': '/',
           'service.name': 'fastify',
           'hook.callback.name': 'helloworld'
         })
-        t.assert.equal(end.parentSpanId, start.spanContext().spanId)
-        t.assert.equal(response.status, 200)
-        t.assert.equal(await response.text(), 'hello world')
+        assert.equal(end.parentSpanId, start.spanContext().spanId)
+        assert.equal(response.status, 200)
+        assert.equal(await response.text(), 'hello world')
       })
 
       test('should respect context (error scenario)', async t => {
@@ -1128,16 +1110,15 @@ describe('FastifyInstrumentation', () => {
 
         const [start] = spans
 
-        t.plan(3)
-        t.assert.equal(spans.length, 1)
-        t.assert.deepStrictEqual(start.attributes, {
+        assert.equal(spans.length, 1)
+        assert.deepStrictEqual(start.attributes, {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
           'service.name': 'fastify',
           'http.response.status_code': 500
         })
-        t.assert.equal(response.status, 500)
+        assert.equal(response.status, 500)
       })
     })
   })


### PR DESCRIPTION
Fixes https://github.com/fastify/otel/issues/10

This PR adds a lightweight Fastify v4 support:

1. The NodeJS versions are the one listed in the [LTS policy](https://github.com/fastify/fastify/blob/main/docs/Reference/LTS.md#schedule)
2. So fastify v4 is not tested against NodeJS 14, 16, 18
3. The `fastify-plugin` has been removed so we don't have any blockers based on this module version
4. The `@opentelemetry/*` deps were [always the same used](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-fastify/package.json) for all the fastify's version
5. We may add support for fastify v3, but this would be just a jump of faith because:
  - The supported hooks are a subset of the current listed here
  - The `@opentelemetry/*` was testing fastify v4 only
    - Ref: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2460
  - The `@opentelemetry/*` was testing old Node.js versions
    - [["14", "16", "18", "20", "22"]](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/4f1e605dcc1d76d90e01cb66661fff497daeff65/.github/workflows/test-all-versions.yml#L49)

So I think that:

- adding support for v4 is something needed by the community
- adding support for v3 is something that someone should sponsor if needed

I think this because of this output too: https://craigory.dev/npm-burst/?package=fastify
The 61.6% of our users are still using fastify v4.

<img width="853" alt="image" src="https://github.com/user-attachments/assets/de9b97db-292b-4d23-9eaa-86c1cbea1afc" />
