### PR TITLE
feat: register on initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ app.register((instance, opts, done) => {
 }, { prefix: '/nested' })
 ```
 
+### Automatic plugin registration
+
+The plugin can be automatically registered with `registerOnInitialization` option set to `true`.
+In this case, it is necessary to await fastify instance.
+```js
+// ... in your OTEL setup
+const fastifyOtelInstrumentation = new FastifyOtelInstrumentation({ registerOnInitialization: true });
+
+// ... in your Fastify definition
+const Fastify = require('fastify');
+const app = await fastify();
+```
+
 > **Notes**:
 >
 > - This instrumentation requires `@opentelemetry/http-instrumentation` to be able to propagate the traces all the way back to upstream

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ import { FastifyInstance } from 'fastify'
 export interface FastifyOtelOptions {}
 export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
   servername?: string
+  registerOnInitialization?: boolean
 }
 
 declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,6 +91,27 @@ describe('FastifyInstrumentation', () => {
       memoryExporter.reset()
     })
 
+    test('should attach plugin if registerOnInitialization is true', async () => {
+      const instrumentation = new FastifyInstrumentation({ registerOnInitialization: true })
+      assert.notEqual(instrumentation._handleInitialization, undefined)
+
+      const app = await Fastify()
+      assert.ok(app.hasPlugin('@fastify/otel'))
+      app.close()
+
+      instrumentation.disable()
+      assert.equal(instrumentation._handleInitialization, undefined)
+    })
+
+    test('shouldn\'t attach plugin if registerOnInitialization isn\'t set', async () => {
+      const instrumentation = new FastifyInstrumentation()
+      assert.equal(instrumentation._handleInitialization, undefined)
+
+      const app = await Fastify()
+      assert.equal(app.hasPlugin('@fastify/otel'), false)
+      app.close()
+    })
+
     test('should create anonymous span (simple case)', async t => {
       const app = Fastify()
       const plugin = instrumentation.plugin()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR introduces `registerOnInitialization` option to automatically register the plugin using `fastify.initialization` hook.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
