### PR TITLE
fix: Return from patched `addHook`

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         const addHookOriginal = this[kAddHookOriginal]
 
         if (FASTIFY_HOOKS.includes(name)) {
-          addHookOriginal.call(
+          return addHookOriginal.call(
             this,
             name,
             handlerWrapper(hook, {
@@ -283,7 +283,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
             })
           )
         } else {
-          addHookOriginal.call(this, name, hook)
+          return addHookOriginal.call(this, name, hook)
         }
       }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -866,6 +866,17 @@ describe('FastifyInstrumentation', () => {
         message: 'error'
       })
     })
+
+    test('should return the Fastify instance from the patched `addHook`', async t => {
+      const app = Fastify()
+      const plugin = instrumentation.plugin()
+
+      await app.register(plugin)
+
+      const instance = app.addHook('onRequest', function onRequest () {})
+
+      assert.equal(instance, app)
+    })
   })
 
   describe('Encapulated Context', () => {


### PR DESCRIPTION
Returns the original `addHook` call, as it returns the Fastify instance. This is [required by `middie`](https://github.com/fastify/middie/blob/2f7381a4097b8720e4b98999f5b080e3f711dc78/index.js#L41-L44) to chain `addHook` calls.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
