### PR TITLE
fix(types): correct CommonJS export in @fastify/otel typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,19 +24,19 @@ type FastifyError = any
 
 type HookHandlerDoneFunction = <TError extends Error = FastifyError>(err?: TError) => void
 
-export type FastifyPlugin = (
+type FastifyPlugin = (
   instance: FastifyInstance,
   opts: any,
   done: HookHandlerDoneFunction,
 ) => unknown | Promise<unknown>
 
-export interface FastifyOtelOptions {}
-export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
+interface FastifyOtelOptions {}
+interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
   servername?: string
   registerOnInitialization?: boolean
 }
 
-export interface FastifyInstance {
+interface FastifyInstance {
   version: string;
   register: (plugin: any) => FastifyInstance;
   after: (listener?: (err: Error) => void) => FastifyInstance;
@@ -49,11 +49,21 @@ export interface FastifyInstance {
 }
 
 declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {
-  static FastifyInstrumentation: FastifyOtelInstrumentation
+  static FastifyInstrumentation: typeof FastifyOtelInstrumentation
   constructor (config?: FastifyOtelInstrumentationOpts)
   init (): InstrumentationNodeModuleDefinition[]
   plugin (): FastifyPlugin
 }
 
-export default FastifyOtelInstrumentation
-export { FastifyOtelInstrumentation }
+// Declare the CommonJS export object
+declare namespace FastifyOtelInstrumentation {
+  export {
+    FastifyOtelInstrumentation,
+    FastifyOtelInstrumentationOpts,
+    FastifyOtelOptions,
+    FastifyPlugin,
+    FastifyInstance
+  }
+}
+
+export = FastifyOtelInstrumentation


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes https://github.com/fastify/otel/issues/24

- Fix default and named exports in mjs consumers by assigning module.exports and module.exports.FastifyOtelInstrumentation instead of adding static properties to the class. The properties show up as `module.exports` in mjs and named exports were not working before. Now they are importable in cjs and mjs as one would expect.
- Added tests for mjs imports. 
- Convert index.d.ts to use `export = ` because this is a type file for a cjs module so we cannot use `export foo` or `export default` anywhere without introducing a mismatch between the module system being used in the implementation and types.
- Move the pure types into a type.d.ts file, where we can use named exports, since exporting them out of a cjs type file is very weird and awkward and requires typeof use by consumers. 
- Moved the fastify mocks from https://github.com/fastify/otel/issues/32
 to a fastify-mocks.d.ts file to also use named exports but to also discourage their import from consumers, just in case their editor tries to import a fastify type incorrectly out of this module. In general mocking these types seems like it's asking for trouble from a maintenance perspective. Fastify was previously an unlisted peer dependency (presumably because listed peer dependencies can be a nightmare) just as it is in nearly every other fastify plugin. Mocking these types will require ongoing one-off maintenance and will also potentially mask breaking issues as they materialize. Maybe someone more familiar with the deliberate strategy of using unlisted peer dependencies can chime in. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
