### PR TITLE
fix(types): named and default exports and types in MJS 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,13 @@
 /// <reference types="node" />
 
-import { Context, Span, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
-import { InstrumentationBase, InstrumentationConfig, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation'
+import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation'
 import { FastifyPluginCallback } from 'fastify'
 
-export interface FastifyOtelOptions {}
-export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
-  servername?: string
-  registerOnInitialization?: boolean
-}
-export type FastifyOtelRequestContext = {
-  span: Span,
-  tracer: Tracer,
-  context: Context,
-  inject: (carrier: {}, setter?: TextMapSetter) => void;
-  extract: (carrier: {}, getter?: TextMapGetter) => Context
-}
+import {
+  FastifyOtelInstrumentationOpts,
+  FastifyOtelOptions,
+  FastifyOtelRequestContext
+} from './types'
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -23,12 +15,20 @@ declare module 'fastify' {
   }
 }
 
-declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {
-  static FastifyInstrumentation: FastifyOtelInstrumentation
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare class FastifyOtelInstrumentationClass<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {
+  servername: string
   constructor (config?: FastifyOtelInstrumentationOpts)
   init (): InstrumentationNodeModuleDefinition[]
   plugin (): FastifyPluginCallback<FastifyOtelOptions>
 }
 
-export default FastifyOtelInstrumentation
-export { FastifyOtelInstrumentation }
+type FastifyOtelInstrumentationClassType = typeof FastifyOtelInstrumentationClass
+
+interface FastifyOtelInstrumentationExport extends FastifyOtelInstrumentationClassType {
+  FastifyOtelInstrumentation: FastifyOtelInstrumentationClassType
+}
+
+declare const exported: FastifyOtelInstrumentationExport
+
+export = exported

--- a/index.js
+++ b/index.js
@@ -48,8 +48,6 @@ const kAddHookOriginal = Symbol('fastify otel addhook original')
 const kSetNotFoundOriginal = Symbol('fastify otel setnotfound original')
 
 class FastifyOtelInstrumentation extends InstrumentationBase {
-  static FastifyOtelInstrumentation = FastifyOtelInstrumentation
-  static default = FastifyOtelInstrumentation
   servername = ''
 
   constructor (config) {
@@ -433,3 +431,4 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
 }
 
 module.exports = FastifyOtelInstrumentation
+module.exports.FastifyOtelInstrumentation = FastifyOtelInstrumentation

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -7,12 +7,13 @@ const Fastify = require(process.env.FASTIFY_VERSION || 'fastify')
 const { InstrumentationBase } = require('@opentelemetry/instrumentation')
 
 const FastifyInstrumentation = require('..')
+const { FastifyOtelInstrumentation } = require('..')
 
 describe('Interface', () => {
   test('should exports support', t => {
     assert.equal(FastifyInstrumentation.name, 'FastifyOtelInstrumentation')
     assert.equal(
-      FastifyInstrumentation.default.name,
+      FastifyOtelInstrumentation.name,
       'FastifyOtelInstrumentation'
     )
     assert.equal(
@@ -29,6 +30,19 @@ describe('Interface', () => {
   test('FastifyInstrumentation#plugin should return a valid Fastify Plugin', async t => {
     const app = Fastify()
     const instrumentation = new FastifyInstrumentation()
+    const plugin = instrumentation.plugin()
+
+    assert.equal(typeof plugin, 'function')
+    assert.equal(plugin.length, 3)
+
+    app.register(plugin)
+
+    await app.ready()
+  })
+
+  test('NamedFastifyInstrumentation#plugin should return a valid Fastify Plugin', async t => {
+    const app = Fastify()
+    const instrumentation = new FastifyOtelInstrumentation()
     const plugin = instrumentation.plugin()
 
     assert.equal(typeof plugin, 'function')

--- a/test/api.test.mjs
+++ b/test/api.test.mjs
@@ -1,0 +1,11 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+
+import DefaultFastifyOtelInstrumentation, { FastifyOtelInstrumentation } from '../index.js'
+
+describe('Interface', () => {
+  test('should Have a default export', t => {
+    assert.equal(DefaultFastifyOtelInstrumentation.name, 'FastifyOtelInstrumentation', 'Default export works')
+    assert.equal(FastifyOtelInstrumentation.name, 'FastifyOtelInstrumentation', 'Named export works')
+  })
+})

--- a/test/env-vars.test-d.ts
+++ b/test/env-vars.test-d.ts
@@ -2,7 +2,8 @@ import { expectAssignable } from 'tsd'
 import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instrumentation'
 import { fastify as Fastify } from 'fastify'
 
-import { FastifyOtelInstrumentation, FastifyOtelInstrumentationOpts } from '..'
+import { FastifyOtelInstrumentation } from '..'
+import { FastifyOtelInstrumentationOpts } from '../types'
 
 expectAssignable<InstrumentationBase>(new FastifyOtelInstrumentation())
 expectAssignable<InstrumentationConfig>({ servername: 'server', enabled: true } as FastifyOtelInstrumentationOpts)

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -3,7 +3,8 @@ import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instr
 import { Context, Span, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
 import { fastify as Fastify, FastifyInstance, FastifyPluginCallback } from 'fastify'
 
-import { FastifyOtelInstrumentation, FastifyOtelInstrumentationOpts } from '..'
+import { FastifyOtelInstrumentation } from '..'
+import { FastifyOtelInstrumentationOpts } from '../types'
 
 expectAssignable<InstrumentationBase>(new FastifyOtelInstrumentation())
 expectAssignable<InstrumentationConfig>({ servername: 'server', enabled: true } as FastifyOtelInstrumentationOpts)

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,17 @@
+// types.d.ts
+import { InstrumentationConfig } from '@opentelemetry/instrumentation'
+import { Context, Span, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
+
+export interface FastifyOtelOptions {}
+export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
+  servername?: string
+  registerOnInitialization?: boolean
+}
+
+export type FastifyOtelRequestContext = {
+  span: Span,
+  tracer: Tracer,
+  context: Context,
+  inject: (carrier: {}, setter?: TextMapSetter) => void;
+  extract: (carrier: {}, getter?: TextMapGetter) => Context
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Here is a second attempt at https://github.com/fastify/otel/pull/30. This does a few things:

- Fix default and named exports in mjs consumers by assigning module.exports and module.exports.FastifyOtelInstrumentation instead of adding static properties to the class. The properties show up as `module.exports` in mjs and named exports were not working before. Now they are importable in cjs and mjs as one would expect.
- Added tests for mjs imports. 
- Convert index.d.ts to use `export = ` because this is a type file for a cjs module so we cannot use `export foo` or `export default` anywhere without introducing a mismatch between the module system being used in the implementation and types.
- Move the pure types into a type.d.ts file, where we can use named exports, since exporting them out of a cjs type file is very weird and awkward and requires typeof use by consumers. 
- Moved the fastify mocks from https://github.com/fastify/otel/issues/32
 to a fastify-mocks.d.ts file to also use named exports but to also discourage their import from consumers, just in case their editor tries to import a fastify type incorrectly out of this module. In general mocking these types seems like it's asking for trouble from a maintenance perspective. Fastify was previously an unlisted peer dependency (presumably because listed peer dependencies can be a nightmare) just as it is in nearly every other fastify plugin. Mocking these types will require ongoing one-off maintenance and will also potentially mask breaking issues as they materialize. Maybe someone more familiar with the deliberate strategy of using unlisted peer dependencies can chime in. 

Fixes: https://github.com/fastify/otel/issues/24

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
