### PR TITLE
feat(#44): align APIs with previous instrumentation

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -45,22 +45,20 @@ describe('Interface', () => {
     const instrumentation = new FastifyInstrumentation()
     const plugin = instrumentation.plugin()
 
-    t.plan(9)
-
     await app.register(plugin)
 
     app.get('/', (request, reply) => {
       const otel = request.opentelemetry()
 
-      t.assert.equal(typeof otel.span.spanContext().spanId, 'string')
-      t.assert.equal(typeof otel.tracer, 'object')
-      t.assert.equal(typeof otel.context, 'object')
-      t.assert.equal(typeof otel.inject, 'function')
-      t.assert.equal(otel.inject.length, 2)
-      t.assert.ok(!otel.inject({}))
-      t.assert.equal(typeof otel.extract, 'function')
-      t.assert.equal(otel.extract.length, 2)
-      t.assert.equal(typeof (otel.extract({})), 'object')
+      assert.equal(typeof otel.span.spanContext().spanId, 'string')
+      assert.equal(typeof otel.tracer, 'object')
+      assert.equal(typeof otel.context, 'object')
+      assert.equal(typeof otel.inject, 'function')
+      assert.equal(otel.inject.length, 2)
+      assert.ok(!otel.inject({}))
+      assert.equal(typeof otel.extract, 'function')
+      assert.equal(otel.extract.length, 2)
+      assert.equal(typeof (otel.extract({})), 'object')
 
       return 'world'
     })

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const { test, describe } = require('node:test')
-const assert = require('assert')
+const assert = require('node:assert')
 const Fastify = require(process.env.FASTIFY_VERSION || 'fastify')
 
 const { InstrumentationBase } = require('@opentelemetry/instrumentation')
+const { trace, context } = require('@opentelemetry/api')
 
 const FastifyInstrumentation = require('..')
 
@@ -37,5 +38,37 @@ describe('Interface', () => {
     app.register(plugin)
 
     await app.ready()
+  })
+
+  test('FastifyInstrumentation#plugin should expose the right set of APIs', async t => {
+    /** @type {import('fastify').FastifyInstance} */
+    const app = Fastify()
+    const instrumentation = new FastifyInstrumentation()
+    const plugin = instrumentation.plugin()
+
+    t.plan(9)
+
+    await app.register(plugin)
+
+    app.get('/', (request, reply) => {
+      const otel = request.opentelemetry()
+
+      t.assert.equal(typeof otel.span.spanContext().spanId, 'string')
+      t.assert.equal(typeof otel.tracer, 'object')
+      t.assert.equal(typeof otel.context, 'object')
+      t.assert.equal(typeof otel.inject, 'function')
+      t.assert.equal(otel.inject.length, 2)
+      t.assert.ok(!otel.inject({}))
+      t.assert.equal(typeof otel.extract, 'function')
+      t.assert.equal(otel.extract.length, 2)
+      t.assert.equal(typeof (otel.extract({})), 'object')
+
+      return 'world'
+    })
+
+    await app.inject({
+      method: 'GET',
+      url: '/'
+    })
   })
 })

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -5,7 +5,6 @@ const assert = require('node:assert')
 const Fastify = require(process.env.FASTIFY_VERSION || 'fastify')
 
 const { InstrumentationBase } = require('@opentelemetry/instrumentation')
-const { trace, context } = require('@opentelemetry/api')
 
 const FastifyInstrumentation = require('..')
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,8 +1,9 @@
 import { expectAssignable } from 'tsd'
 import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instrumentation'
-import { fastify as Fastify } from 'fastify'
+import { Context, Span, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
+import { fastify as Fastify, FastifyInstance, FastifyPluginCallback } from 'fastify'
 
-import { FastifyOtelInstrumentation, FastifyOtelInstrumentationOpts, FastifyInstance, FastifyPlugin } from '..'
+import { FastifyOtelInstrumentation, FastifyOtelInstrumentationOpts } from '..'
 
 expectAssignable<InstrumentationBase>(new FastifyOtelInstrumentation())
 expectAssignable<InstrumentationConfig>({ servername: 'server', enabled: true } as FastifyOtelInstrumentationOpts)
@@ -12,7 +13,7 @@ const app = Fastify()
 const plugin = new FastifyOtelInstrumentation().plugin()
 
 expectAssignable<FastifyInstance>(app)
-expectAssignable<FastifyPlugin>(plugin)
+expectAssignable<FastifyPluginCallback>(plugin)
 expectAssignable<FastifyInstance>(app.register(plugin))
 expectAssignable<FastifyInstance>(app.register(plugin).register(plugin))
 
@@ -20,4 +21,13 @@ app.register(new FastifyOtelInstrumentation().plugin())
 app.register((nested, _opts, done) => {
   nested.register(new FastifyOtelInstrumentation().plugin())
   done()
+})
+
+app.get('/', async function (request, reply) {
+  const otel = request.opentelemetry()
+  expectAssignable<Span>(otel.span)
+  expectAssignable<Context>(otel.context)
+  expectAssignable<Tracer>(otel.tracer)
+  expectAssignable<(carrier: any, setter?: TextMapSetter) => void>(otel.inject)
+  expectAssignable<(carrier: any, getter?: TextMapGetter) => Context>(otel.extract)
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes #44

> **Note**
> Had to remove the previously vendored types due to conflicts with interface augmentation typical in fastify plugins.

**Pending**
- [x] Documentation
- [x] Tests

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
