### PR TITLE
feat: export `FastifyOtelInstrumentationOpts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,19 +16,16 @@ declare module 'fastify' {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-declare class FastifyOtelInstrumentationClass<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {
+declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {
   servername: string
   constructor (config?: FastifyOtelInstrumentationOpts)
   init (): InstrumentationNodeModuleDefinition[]
   plugin (): FastifyPluginCallback<FastifyOtelOptions>
 }
 
-type FastifyOtelInstrumentationClassType = typeof FastifyOtelInstrumentationClass
-
-interface FastifyOtelInstrumentationExport extends FastifyOtelInstrumentationClassType {
-  FastifyOtelInstrumentation: FastifyOtelInstrumentationClassType
+declare namespace exported {
+  export type { FastifyOtelInstrumentationOpts }
+  export { FastifyOtelInstrumentation }
 }
-
-declare const exported: FastifyOtelInstrumentationExport
 
 export = exported


### PR DESCRIPTION
Had to change export logic to make it possible to export types.

Closes #53 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
