### PR TITLE
feat: `RouteOptions#otel` to disable telemetry for specific routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ app.get('/', () => 'hello world')
 // as well as your instance level hooks.
 app.addHook('onError', () => /* do something */)
 // Manually skip telemetry for a specific route
-app.get('/healthcheck', { otel: false }, () => 'Up!')
+app.get('/healthcheck', { config: { otel: false } }, () => 'Up!')
 
 // you can also scope your instrumentation to only be enabled on a sub context
 // of your application

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ await app.register(fastifyOtelInstrumentation.plugin());
 app.get('/', () => 'hello world')
 // as well as your instance level hooks.
 app.addHook('onError', () => /* do something */)
+// Manually skip telemetry for a specific route
+app.get('/healthcheck', { otel: false }, () => 'Up!')
 
 // you can also scope your instrumentation to only be enabled on a sub context
 // of your application

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare module 'fastify' {
     opentelemetry(): FastifyOtelRequestContext
   }
 
-  interface RouteShorthandOptions {
+  interface FastifyContextConfig {
     /** Set this to `true` to disable OpenTelemetry for the route */
     otel: boolean
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare module 'fastify' {
   }
 
   interface FastifyContextConfig {
-    /** Set this to `true` to disable OpenTelemetry for the route */
+    /** Set this to `false` to disable OpenTelemetry for the route */
     otel: boolean
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 /// <reference types="node" />
 
-import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation'
-import { FastifyPluginCallback } from 'fastify'
+import { InstrumentationBase, type InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation'
+import type { FastifyPluginCallback } from 'fastify'
 
-import {
+import type {
   FastifyOtelInstrumentationOpts,
   FastifyOtelOptions,
   FastifyOtelRequestContext
@@ -12,6 +12,11 @@ import {
 declare module 'fastify' {
   interface FastifyRequest {
     opentelemetry(): FastifyOtelRequestContext
+  }
+
+  interface RouteShorthandOptions {
+    /** Set this to `true` to disable OpenTelemetry for the route */
+    otel: boolean
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -146,7 +146,6 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
       })
       instance.decorateRequest(kRequestSpan, null)
       instance.decorateRequest(kRequestContext, null)
-      // instance.decorateRequest(kSkipRequest, false)
 
       instance.addHook('onRoute', function (routeOptions) {
         if (instrumentation[kIgnorePaths]?.(routeOptions) === true) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -86,10 +86,11 @@ describe('Interface', () => {
       return 'world'
     })
 
-    await app.inject({
+    const res = await app.inject({
       method: 'GET',
       url: '/'
     })
+    assert.equal(res.payload, 'world')
   })
 
   test('FastifyRequest#opentelemetry() returns FastifyDisabledOtelRequestContext when disabled for a request', async () => {
@@ -100,7 +101,7 @@ describe('Interface', () => {
 
     await app.register(plugin)
 
-    app.get('/', { otel: false }, (request) => {
+    app.get('/', { config: { otel: false } }, (request) => {
       const otel = request.opentelemetry()
 
       assert.equal(otel.enabled, false)
@@ -117,7 +118,7 @@ describe('Interface', () => {
       return 'world'
     })
 
-    app.get('/withOtel', { otel: true }, (request) => {
+    app.get('/withOtel', { config: { otel: true } }, (request) => {
       const otel = request.opentelemetry()
 
       assert.equal(otel.enabled, true)
@@ -134,7 +135,7 @@ describe('Interface', () => {
       return 'world'
     })
 
-    app.get('/withOnRequest', { otel: false, async onRequest (req) { req.fakeData = 123 } }, (request) => {
+    app.get('/withOnRequest', { config: { otel: false }, async onRequest (req) { req.fakeData = 123 } }, (request) => {
       const otel = request.opentelemetry()
 
       assert.equal(request.fakeData, 123)
@@ -155,7 +156,7 @@ describe('Interface', () => {
     app.get(
       '/withManyOnRequest',
       {
-        otel: false,
+        config: { otel: false },
         onRequest: [
           function decorated (_request, _reply, _error, done) {
             done()
@@ -186,19 +187,25 @@ describe('Interface', () => {
       }
     )
 
-    await app.inject({
+    const res1 = await app.inject({
       method: 'GET',
       url: '/'
     })
+    assert.equal(res1.statusCode, 200)
+    assert.equal(res1.payload, 'world')
 
-    await app.inject({
+    const res2 = await app.inject({
       method: 'GET',
       url: '/withOtel'
     })
+    assert.equal(res2.statusCode, 200)
+    assert.equal(res2.payload, 'world')
 
-    await app.inject({
+    const res3 = await app.inject({
       method: 'GET',
       url: '/withOnRequest'
     })
+    assert.equal(res3.statusCode, 200)
+    assert.equal(res3.payload, 'world')
   })
 })

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -26,9 +26,16 @@ app.register((nested, _opts, done) => {
 
 app.get('/', async function (request, reply) {
   const otel = request.opentelemetry()
-  expectAssignable<Span>(otel.span)
-  expectAssignable<Context>(otel.context)
-  expectAssignable<Tracer>(otel.tracer)
+
   expectAssignable<(carrier: any, setter?: TextMapSetter) => void>(otel.inject)
   expectAssignable<(carrier: any, getter?: TextMapGetter) => Context>(otel.extract)
+  expectAssignable<Tracer>(otel.tracer)
+
+  if (otel.enabled) {
+    expectAssignable<Span>(otel.span)
+    expectAssignable<Context>(otel.context)
+  } else {
+    expectAssignable<null>(otel.span)
+    expectAssignable<null>(otel.context)
+  }
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 // types.d.ts
-import { InstrumentationConfig } from '@opentelemetry/instrumentation'
-import { Context, Span, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
-import { HTTPMethods } from 'fastify'
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation'
+import type { Context, Span, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
+import type { HTTPMethods } from 'fastify'
 
 export interface FastifyOtelOptions {}
 export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
@@ -10,10 +10,22 @@ export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
   ignorePaths?: string | ((routeOpts: { url: string, method: HTTPMethods }) => boolean);
 }
 
-export type FastifyOtelRequestContext = {
-  span: Span,
+interface FastifyOtelRequestInfo {
   tracer: Tracer,
-  context: Context,
   inject: (carrier: {}, setter?: TextMapSetter) => void;
   extract: (carrier: {}, getter?: TextMapGetter) => Context
 }
+
+export interface FastifyEnabledOtelRequestContext extends FastifyOtelRequestInfo {
+  enabled: true,
+  span: Span,
+  context: Context,
+}
+
+export interface FastifyDisabledOtelRequestContext extends FastifyOtelRequestInfo {
+  enabled: false,
+  span: null,
+  context: null,
+}
+
+export type FastifyOtelRequestContext = FastifyEnabledOtelRequestContext | FastifyDisabledOtelRequestContext


### PR DESCRIPTION
Closes #52

A new symbol is needed to decorate on the request object so it can be later used in the `onRequest` to ensure that nothing related to otel run on such requests, reducing runtime overhead.

On requests with `otel: false` or matching `ignorePaths`, `req.opentelemetry()` returns a different data type, this PR also fixes that.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
