### PR TITLE
fix(types): add default export for FastifyOtelInstrumentation

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,6 @@ declare module 'fastify' {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {
   servername: string
   constructor (config?: FastifyOtelInstrumentationOpts)
@@ -31,6 +30,7 @@ declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentati
 declare namespace exported {
   export type { FastifyOtelInstrumentationOpts }
   export { FastifyOtelInstrumentation }
+  export { FastifyOtelInstrumentation as default }
 }
 
 export = exported

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -3,10 +3,11 @@ import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instr
 import { Context, Span, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
 import { fastify as Fastify, FastifyInstance, FastifyPluginCallback } from 'fastify'
 
-import { FastifyOtelInstrumentation } from '.'
+import FastifyInstrumentation, { FastifyOtelInstrumentation } from '.'
 import { FastifyOtelInstrumentationOpts } from './types'
 
 expectAssignable<InstrumentationBase>(new FastifyOtelInstrumentation())
+expectAssignable<InstrumentationBase>(new FastifyInstrumentation())
 expectAssignable<InstrumentationConfig>({ servername: 'server', enabled: true } as FastifyOtelInstrumentationOpts)
 expectAssignable<InstrumentationConfig>({} as FastifyOtelInstrumentationOpts)
 


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
