### PR TITLE
feat: add requestHook support to FastifyOtelInstrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If a string is provided, it will be used as a glob match pattern.
 If a function is provided, it will be called with the request options and should return true if the path should be ignored.
 
 #### `FastifyOtelInstrumentationOptions#requestHook: function`
-A callback that runs **immediately after the root request span is created**.
+A **synchronous** callback that runs immediately after the root request span is created.
 * **span** – the newly-created `Span`
 * **info.request** – the current `FastifyRequest`
 
@@ -203,7 +203,7 @@ const fastifyOtelInstrumentation = new FastifyOtelInstrumentation({
 ```js
 const otel = new FastifyOtelInstrumentation({
   servername: 'my-app',
-  requestHook: (span, { request }) => {
+  requestHook: (span, request) => {
     // attach user info
     span.setAttribute('user.id', request.headers['x-user-id'] ?? 'anonymous')
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,16 @@ If a string is provided, it will be used as a glob match pattern.
 
 If a function is provided, it will be called with the request options and should return true if the path should be ignored.
 
-#### Example
+#### `FastifyOtelInstrumentationOptions#requestHook: function`
+A callback that runs **immediately after the root request span is created**.
+* **span** – the newly-created `Span`
+* **info.request** – the current `FastifyRequest`
+
+Use it to add custom attributes, events, or rename the span.  
+If the function throws, the error is caught and logged so the request flow is never interrupted.
+
+
+#### Examples
 
 ```ts
 import { FastifyOtelInstrumentation } from '@fastify/otel';
@@ -189,6 +198,19 @@ const fastifyOtelInstrumentation = new FastifyOtelInstrumentation({
     return opts.url.startsWith('/ignore');
   },
 });
+```
+
+```js
+const otel = new FastifyOtelInstrumentation({
+  servername: 'my-app',
+  requestHook: (span, { request }) => {
+    // attach user info
+    span.setAttribute('user.id', request.headers['x-user-id'] ?? 'anonymous')
+
+    // optional: give the span a cleaner name
+    span.updateName(`${request.method} ${request.routerPath}`)
+  }
+})
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -51,12 +51,16 @@ const kIgnorePaths = Symbol('fastify otel ignore path')
 class FastifyOtelInstrumentation extends InstrumentationBase {
   servername = ''
   logger = null
+  _requestHook = null
 
   constructor (config) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config)
     this.servername = config?.servername ?? process.env.OTEL_SERVICE_NAME ?? 'fastify'
     this.logger = diag.createComponentLogger({ namespace: PACKAGE_NAME })
     this[kIgnorePaths] = null
+    if (typeof config?.requestHook === 'function') {
+      this._requestHook = config.requestHook
+    }
 
     if (config?.ignorePaths != null || process.env.OTEL_FASTIFY_IGNORE_PATHS != null) {
       const ignorePaths = config?.ignorePaths ?? process.env.OTEL_FASTIFY_IGNORE_PATHS
@@ -276,6 +280,12 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
             [ATTR_HTTP_REQUEST_METHOD]: request.method
           }
         }, ctx)
+
+        try {
+          this[kInstrumentation]._requestHook?.(span, { request })
+        } catch (err) {
+          this[kInstrumentation].logger.error('requestHook threw', err)
+        }
 
         request[kRequestContext] = trace.setSpan(ctx, span)
         request[kRequestSpan] = span

--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         }, ctx)
 
         try {
-          this[kInstrumentation]._requestHook?.(span, { request })
+          this[kInstrumentation]._requestHook?.(span, request)
         } catch (err) {
           this[kInstrumentation].logger.error({ err }, 'requestHook threw')
         }

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         try {
           this[kInstrumentation]._requestHook?.(span, { request })
         } catch (err) {
-          this[kInstrumentation].logger.error('requestHook threw', err)
+          this[kInstrumentation].logger.error({ err }, 'requestHook threw')
         }
 
         request[kRequestContext] = trace.setSpan(ctx, span)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentati
   constructor (config?: FastifyOtelInstrumentationOpts)
   init (): InstrumentationNodeModuleDefinition[]
   plugin (): FastifyPluginCallback<FastifyOtelOptions>
-  requestHook?: (span: import('@opentelemetry/api').Span, info: { request: import('fastify').FastifyRequest }) => void
+  requestHook?: (span: import('@opentelemetry/api').Span, request: import('fastify').FastifyRequest) => void
 }
 
 declare namespace exported {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,6 +25,7 @@ declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentati
   constructor (config?: FastifyOtelInstrumentationOpts)
   init (): InstrumentationNodeModuleDefinition[]
   plugin (): FastifyPluginCallback<FastifyOtelOptions>
+  requestHook?: (span: import('@opentelemetry/api').Span, info: { request: import('fastify').FastifyRequest }) => void
 }
 
 declare namespace exported {


### PR DESCRIPTION
Adds support for a requestHook option to customize the root request span.
The hook is called right after the span is created. If it throws, the error is caught and logged to avoid breaking the request flow.
Includes tests for both successful and throwing hooks.

fixes #64
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
