### PR TITLE
feat: Don't set ATTR_SERVICE_NAME in fastify instrumentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Example:
 // ... in your OTEL setup
 const FastifyOtelInstrumentation = require('@fastify/otel');
 
-// If serverName is not provided, it will fallback to OTEL_SERVICE_NAME
+// Service name comes from OpenTelemetry resources (via NodeSDK or OTEL_SERVICE_NAME)
 // as per https://opentelemetry.io/docs/languages/sdk-configuration/general/.
-const fastifyOtelInstrumentation = new FastifyOtelInstrumentation({ servername: '<yourCustomApplicationName>' });
+const fastifyOtelInstrumentation = new FastifyOtelInstrumentation();
 fastifyOtelInstrumentation.setTracerProvider(provider)
 
 module.exports = { fastifyOtelInstrumentation }
@@ -164,9 +164,7 @@ app.get('/', (req, reply) => {
 
 The options for the `FastifyOtelInstrumentation` class.
 
-#### `FastifyOtelInstrumentationOptions#serverName: string`
 
-The name of the server. If not provided, it will fallback to `OTEL_SERVICE_NAME` as per [OpenTelemetry SDK Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/general/).
 
 #### `FastifyOtelInstrumentationOptions#registerOnInitialization: boolean`
 
@@ -187,7 +185,7 @@ A **synchronous** callback that runs immediately after the root request span is 
 * **span** – the newly-created `Span`
 * **info.request** – the current `FastifyRequest`
 
-Use it to add custom attributes, events, or rename the span.  
+Use it to add custom attributes, events, or rename the span.
 If the function throws, the error is caught and logged so the request flow is never interrupted.
 
 
@@ -197,18 +195,20 @@ If the function throws, the error is caught and logged so the request flow is ne
 import { FastifyOtelInstrumentation } from '@fastify/otel';
 
 const fastifyOtelInstrumentation = new FastifyOtelInstrumentation({
-  serverName: 'my-server',
   registerOnInitialization: true,
   ignorePaths: (opts) => {
     // Ignore all paths that start with /ignore
     return opts.url.startsWith('/ignore');
   },
 });
+
+// Service name should be set via environment variable:
+// export OTEL_SERVICE_NAME=my-server
+// or via NodeSDK resource configuration
 ```
 
 ```js
 const otel = new FastifyOtelInstrumentation({
-  servername: 'my-app',
   requestHook: (span, request) => {
     // attach user info
     span.setAttribute('user.id', request.headers['x-user-id'] ?? 'anonymous')

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -26,7 +26,6 @@ describe('Interface', () => {
       Object.getPrototypeOf(FastifyInstrumentation),
       InstrumentationBase
     )
-    assert.strictEqual(new FastifyInstrumentation({ servername: 'test' }).servername, 'test')
   })
 
   test('FastifyInstrumentation#plugin should return a valid Fastify Plugin', async t => {

--- a/test/env-vars.test.js
+++ b/test/env-vars.test.js
@@ -57,7 +57,7 @@ describe('Environment variable aware FastifyInstrumentation', () => {
       memoryExporter.reset()
     })
 
-    test('should create span with service.name equal to general sdk configuration', async t => {
+    test('should create spans with fastify-specific attributes (service.name comes from resource)', async t => {
       const app = Fastify()
       const plugin = instrumentation.plugin()
 
@@ -83,7 +83,6 @@ describe('Environment variable aware FastifyInstrumentation', () => {
       assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
-        'service.name': 'my_app',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
@@ -91,7 +90,6 @@ describe('Environment variable aware FastifyInstrumentation', () => {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'my_app',
         'hook.callback.name': 'anonymous'
       })
       assert.equal(response.status, 200)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -210,7 +210,6 @@ describe('FastifyInstrumentation', () => {
       assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
-        'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
@@ -220,7 +219,6 @@ describe('FastifyInstrumentation', () => {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'anonymous'
       })
       assert.equal(response.status, 200)
@@ -277,7 +275,6 @@ describe('FastifyInstrumentation', () => {
       assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
-        'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
@@ -286,7 +283,6 @@ describe('FastifyInstrumentation', () => {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -325,7 +321,6 @@ describe('FastifyInstrumentation', () => {
       assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
-        'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
@@ -335,7 +330,6 @@ describe('FastifyInstrumentation', () => {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -387,7 +381,6 @@ describe('FastifyInstrumentation', () => {
       assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
-        'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
@@ -398,7 +391,6 @@ describe('FastifyInstrumentation', () => {
         'hook.callback.name': 'onRequest1',
         'hook.name': 'fastify -> @fastify/otel - route -> onRequest',
         'http.route': '/',
-        'service.name': 'fastify',
       })
       assert.equal(onReq2.name, 'onRequest - fastify -> @fastify/otel')
       assert.deepStrictEqual(onReq2.attributes, {
@@ -406,7 +398,6 @@ describe('FastifyInstrumentation', () => {
         'hook.callback.name': 'anonymous',
         'hook.name': 'fastify -> @fastify/otel - route -> onRequest',
         'http.route': '/',
-        'service.name': 'fastify',
       })
       assert.equal(preHandler.name, 'preHandler - somePreHandler')
       assert.deepStrictEqual(preHandler.attributes, {
@@ -414,7 +405,6 @@ describe('FastifyInstrumentation', () => {
         'hook.callback.name': 'somePreHandler',
         'hook.name': 'fastify -> @fastify/otel - route -> preHandler',
         'http.route': '/',
-        'service.name': 'fastify',
       })
       assert.equal(end.name, 'handler - helloworld')
       assert.deepStrictEqual(end.attributes, {
@@ -422,7 +412,6 @@ describe('FastifyInstrumentation', () => {
         'fastify.type': 'request-handler',
         'http.route': '/',
         'hook.callback.name': 'helloworld',
-        'service.name': 'fastify',
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
       assert.equal(response.status, 200)
@@ -475,7 +464,6 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
-        'service.name': 'fastify',
         'http.response.status_code': 200
       })
       assert.equal(onReq1.name, 'onSend - onSend')
@@ -483,14 +471,12 @@ describe('FastifyInstrumentation', () => {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'onSend',
         'hook.name': 'fastify -> @fastify/otel - route -> onSend',
-        'service.name': 'fastify',
         'http.route': '/'
       })
       assert.equal(preValidation.name, 'preValidation - preValidation')
       assert.deepStrictEqual(preValidation.attributes, {
         'fastify.type': 'hook',
         'hook.callback.name': 'preValidation',
-        'service.name': 'fastify',
         'hook.name': 'fastify -> @fastify/otel - preValidation'
       })
       assert.equal(end.name, 'handler - helloworld')
@@ -498,7 +484,6 @@ describe('FastifyInstrumentation', () => {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -539,14 +524,12 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
-        'service.name': 'fastify',
         'http.response.status_code': 500
       })
       assert.equal(preHandler.name, 'preHandler - fastify -> @fastify/otel')
       assert.deepStrictEqual(preHandler.attributes, {
         'fastify.type': 'hook',
         'hook.callback.name': 'anonymous',
-        'service.name': 'fastify',
         'hook.name': 'fastify -> @fastify/otel - preHandler'
       })
       assert.equal(preHandler.status.code, SpanStatusCode.ERROR)
@@ -585,7 +568,6 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
-        'service.name': 'fastify',
         'http.response.status_code': 404
       })
     })
@@ -625,14 +607,12 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
-        'service.name': 'fastify',
         'http.response.status_code': 404
       })
       assert.equal(fof.name, 'notFoundHandler - notFoundHandler')
       assert.deepStrictEqual(fof.attributes, {
         'hook.name': 'fastify -> @fastify/otel - not-found-handler',
         'fastify.type': 'hook',
-        'service.name': 'fastify',
         'hook.callback.name': 'notFoundHandler'
       })
     })
@@ -695,27 +675,23 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
-        'service.name': 'fastify',
         'http.response.status_code': 404
       })
       assert.deepStrictEqual(preHandler.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preHandler',
         'fastify.type': 'hook',
-        'service.name': 'fastify',
         'hook.callback.name': 'preHandler'
       })
       assert.deepStrictEqual(preValidation.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preValidation',
         'fastify.type': 'hook',
-        'service.name': 'fastify',
         'hook.callback.name': 'preValidation'
       })
       assert.deepStrictEqual(fof.attributes, {
         'hook.name': 'fastify -> @fastify/otel - not-found-handler',
         'fastify.type': 'hook',
-        'service.name': 'fastify',
         'hook.callback.name': 'notFoundHandler'
       })
       assert.equal(fof.parentSpanId, start.spanContext().spanId)
@@ -781,27 +757,23 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'POST',
-        'service.name': 'fastify',
         'http.response.status_code': 404
       })
       assert.deepStrictEqual(preHandler.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preHandler',
         'fastify.type': 'hook',
-        'service.name': 'fastify',
         'hook.callback.name': 'preHandler'
       })
       assert.deepStrictEqual(preValidation.attributes, {
         'hook.name':
           'fastify -> @fastify/otel - not-found-handler - preValidation',
         'fastify.type': 'hook',
-        'service.name': 'fastify',
         'hook.callback.name': 'preValidation'
       })
       assert.deepStrictEqual(fof.attributes, {
         'hook.name': 'fastify -> @fastify/otel - not-found-handler',
         'fastify.type': 'hook',
-        'service.name': 'fastify',
         'hook.callback.name': 'notFoundHandler'
       })
       assert.equal(fof.parentSpanId, start.spanContext().spanId)
@@ -845,7 +817,6 @@ describe('FastifyInstrumentation', () => {
       assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
-        'service.name': 'fastify',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })
@@ -853,7 +824,6 @@ describe('FastifyInstrumentation', () => {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -898,14 +868,12 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
-        'service.name': 'fastify',
         'http.response.status_code': 500
       })
       assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -957,7 +925,6 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
-        'service.name': 'fastify',
         'http.response.status_code': 500
       })
       assert.deepStrictEqual(error.attributes, {
@@ -965,13 +932,11 @@ describe('FastifyInstrumentation', () => {
         'hook.callback.name': 'decorated',
         'hook.name': 'fastify -> @fastify/otel - route -> onError',
         'http.route': '/',
-        'service.name': 'fastify',
       })
       assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -1028,28 +993,24 @@ describe('FastifyInstrumentation', () => {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
         'http.request.method': 'GET',
-        'service.name': 'fastify',
         'http.response.status_code': 500
       })
       assert.deepStrictEqual(error.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'decorated',
         'hook.name': 'fastify -> @fastify/otel - route -> onError',
-        'service.name': 'fastify',
         'http.route': '/'
       })
       assert.deepStrictEqual(error2.attributes, {
         'fastify.type': 'route-hook',
         'hook.callback.name': 'decorated2',
         'hook.name': 'fastify -> @fastify/otel - route -> onError',
-        'service.name': 'fastify',
         'http.route': '/'
       })
       assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
         'fastify.type': 'request-handler',
         'http.route': '/',
-        'service.name': 'fastify',
         'hook.callback.name': 'helloworld'
       })
       assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -1160,14 +1121,12 @@ describe('FastifyInstrumentation', () => {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
-          'service.name': 'fastify',
           'http.response.status_code': 200
         })
         assert.equal(end.name, 'handler - plugin')
         assert.deepStrictEqual(end.attributes, {
           'hook.name': 'plugin - route-handler',
           'fastify.type': 'request-handler',
-          'service.name': 'fastify',
           'http.route': '/',
           'hook.callback.name': 'anonymous'
         })
@@ -1206,7 +1165,6 @@ describe('FastifyInstrumentation', () => {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
-          'service.name': 'fastify',
           'http.response.status_code': 200
         })
         assert.equal(end.name, 'handler - helloworld')
@@ -1214,7 +1172,6 @@ describe('FastifyInstrumentation', () => {
           'hook.name': 'nested -> @fastify/otel - route-handler',
           'fastify.type': 'request-handler',
           'http.route': '/',
-          'service.name': 'fastify',
           'hook.callback.name': 'helloworld'
         })
         assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -1272,7 +1229,6 @@ describe('FastifyInstrumentation', () => {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
-          'service.name': 'fastify',
           'http.response.status_code': 200
         })
         assert.equal(onReq1.name, 'onSend - onSend')
@@ -1280,14 +1236,12 @@ describe('FastifyInstrumentation', () => {
           'fastify.type': 'route-hook',
           'hook.callback.name': 'onSend',
           'hook.name': 'nested - route -> onSend',
-          'service.name': 'fastify',
           'http.route': '/'
         })
         assert.equal(preValidation.name, 'preValidation - nested')
         assert.deepStrictEqual(preValidation.attributes, {
           'fastify.type': 'hook',
           'hook.callback.name': 'anonymous',
-          'service.name': 'fastify',
           'hook.name': 'nested - preValidation'
         })
         assert.equal(end.name, 'handler - helloworld')
@@ -1295,7 +1249,6 @@ describe('FastifyInstrumentation', () => {
           'hook.name': 'nested - route-handler',
           'fastify.type': 'request-handler',
           'http.route': '/',
-          'service.name': 'fastify',
           'hook.callback.name': 'helloworld'
         })
         assert.equal(end.parentSpanId, start.spanContext().spanId)
@@ -1339,7 +1292,6 @@ describe('FastifyInstrumentation', () => {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
-          'service.name': 'fastify',
           'http.response.status_code': 500
         })
         assert.equal(response.status, 500)
@@ -1407,38 +1359,32 @@ describe('FastifyInstrumentation', () => {
         assert.deepStrictEqual(preValidation.attributes, {
           'fastify.type': 'hook',
           'hook.callback.name': 'anonymous',
-          'service.name': 'fastify',
           'hook.name': 'nested - preValidation'
         })
         assert.deepStrictEqual(end.attributes, {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
-          'service.name': 'fastify',
           'http.response.status_code': 200
         })
         assert.deepStrictEqual(start.attributes, {
           'hook.name': 'nested - route-handler',
           'fastify.type': 'request-handler',
           'http.route': '/',
-          'service.name': 'fastify',
           'hook.callback.name': 'helloworld'
         })
         assert.deepStrictEqual(preHandler2.attributes, {
-          'service.name': 'fastify',
           'hook.name': 'nested2 - preHandler',
           'fastify.type': 'hook',
           'hook.callback.name': 'anonymous'
         })
         assert.deepStrictEqual(end2.attributes, {
-          'service.name': 'fastify',
           'fastify.root': '@fastify/otel',
           'http.route': '/nested2',
           'http.request.method': 'GET',
           'http.response.status_code': 500
         })
         assert.deepStrictEqual(preValidation2.attributes, {
-          'service.name': 'fastify',
           'hook.name': 'nested - preValidation',
           'fastify.type': 'hook',
           'hook.callback.name': 'anonymous'
@@ -1487,7 +1433,6 @@ describe('FastifyInstrumentation', () => {
           'fastify.root': '@fastify/otel',
           'http.route': '/',
           'http.request.method': 'GET',
-          'service.name': 'fastify',
           'http.response.status_code': 500
         })
         assert.equal(response.status, 500)

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -59,7 +59,6 @@ describe('FastifyOtelInstrumentation with opentelemetry.NodeSDK', () => {
       'hook.callback.name': 'anonymous',
       'hook.name': 'fastify - route-handler',
       'http.route': '/qq',
-      'service.name': 'fastify',
     })
     assert.deepStrictEqual(spans[1].name, 'request')
     assert.deepStrictEqual(spans[1].attributes, {
@@ -67,7 +66,6 @@ describe('FastifyOtelInstrumentation with opentelemetry.NodeSDK', () => {
       'http.request.method': 'GET',
       'http.response.status_code': 200,
       'http.route': '/qq',
-      'service.name': 'fastify',
     })
   })
 
@@ -102,7 +100,6 @@ describe('FastifyOtelInstrumentation with opentelemetry.NodeSDK', () => {
       'hook.callback.name': 'anonymous',
       'hook.name': 'fastify -> @fastify/otel - route-handler',
       'http.route': '/qq',
-      'service.name': 'fastify',
     })
     assert.deepStrictEqual(spans[1].name, 'request')
     assert.deepStrictEqual(spans[1].attributes, {
@@ -110,7 +107,6 @@ describe('FastifyOtelInstrumentation with opentelemetry.NodeSDK', () => {
       'http.request.method': 'GET',
       'http.response.status_code': 200,
       'http.route': '/qq',
-      'service.name': 'fastify',
     })
   })
 })

--- a/types/env-vars.test-d.ts
+++ b/types/env-vars.test-d.ts
@@ -6,7 +6,7 @@ import { FastifyOtelInstrumentation } from '.'
 import { FastifyOtelInstrumentationOpts } from './types'
 
 expectAssignable<InstrumentationBase>(new FastifyOtelInstrumentation())
-expectAssignable<InstrumentationConfig>({ servername: 'server', enabled: true } as FastifyOtelInstrumentationOpts)
+expectAssignable<InstrumentationConfig>({ enabled: true } as FastifyOtelInstrumentationOpts)
 expectAssignable<InstrumentationConfig>({} as FastifyOtelInstrumentationOpts)
 
 const app = Fastify()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,6 @@ declare module 'fastify' {
 }
 
 declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentationOpts = FastifyOtelInstrumentationOpts> extends InstrumentationBase<Config> {
-  servername: string
   constructor (config?: FastifyOtelInstrumentationOpts)
   init (): InstrumentationNodeModuleDefinition[]
   plugin (): FastifyPluginCallback<FastifyOtelOptions>

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -9,7 +9,6 @@ import { FastifyOtelInstrumentationOpts } from './types'
 expectAssignable<InstrumentationBase>(new FastifyOtelInstrumentation())
 expectAssignable<InstrumentationBase>(new FastifyInstrumentation())
 expectAssignable<InstrumentationConfig>({
-  servername: 'server',
   enabled: true,
   requestHook (span, request) {
     expectAssignable<Span>(span)

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -5,7 +5,6 @@ import type { HTTPMethods } from 'fastify'
 
 export interface FastifyOtelOptions {}
 export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
-  servername?: string
   registerOnInitialization?: boolean
   ignorePaths?: string | ((routeOpts: { url: string, method: HTTPMethods }) => boolean);
   requestHook?: (span: import('@opentelemetry/api').Span, request: import('fastify').FastifyRequest) => void


### PR DESCRIPTION
This PR is adjacent to https://github.com/fastify/otel/pull/69

In trying to understand how to use this otel instrument, I tried setting the `SemanticResourceAttributes.SERVICE_NAME` in the resource field of the NodeSDK instance in my otel setup. I was surprised to see that the fastify instrument wasn't inheriting this the way the other instruments were. I see that I can set this for both by exporting a OTEL_SERVICE_NAME, but if I set it in the NodeSDK constructor, I also have to pass a name to `serverName` in the fastify instrument, which is inconsistent with the other instruments. 

According to the otel spec: 

- https://opentelemetry.io/docs/specs/semconv/resource/
- https://github.com/open-telemetry/opentelemetry-specification/blob/v1.45.0/specification/resource/sdk.md#sdk-provided-resource-attributes

It seems like this is something that should be set on the resource, in the accompanying SDK and not something instruments should be concerned with.

For example, in the http instrument, `ATTR_SERVICE_NAME` is never set

- https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts#L469-L481

Same with GRPC:

- https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts#L456

Also the way this is implemented is that if you omit `serverName` and don't have `OTEL_SERVICE_NAME` exported, but pass in a service name to NodeSDK, your fastify spans will get tagged with a service name of `fastify` as the fallback for `serverName` rather than your service name, which definitely doesn't seem correct. 

This would either be a bug fix or a breaking change, but given how long its been around it should probably be breaking. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
