### PR TITLE
Make otel optional in FastifyContextConfig

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,7 +16,7 @@ declare module 'fastify' {
 
   interface FastifyContextConfig {
     /** Set this to `false` to disable OpenTelemetry for the route */
-    otel: boolean
+    otel?: boolean
   }
 }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -47,3 +47,20 @@ app.get('/', async function (request, reply) {
     expectAssignable<null>(otel.context)
   }
 })
+
+// Test that otel field in FastifyContextConfig is optional
+app.get('/with-config', { config: { } }, async function (_request, _reply) {
+  return { hello: 'world' }
+})
+
+app.get('/with-otel-true', { config: { otel: true } }, async function (_request, _reply) {
+  return { hello: 'world' }
+})
+
+app.get('/with-otel-false', { config: { otel: false } }, async function (_request, _reply) {
+  return { hello: 'world' }
+})
+
+app.get('/with-other-config', { config: { customField: 'value' } }, async function (_request, _reply) {
+  return { hello: 'world' }
+})


### PR DESCRIPTION
I noticed I was forced to set an otel field as soon as I created a config object in my routes. Keeping this optional will let people use other config options without explicitly setting this, similar to other plugins: https://github.com/fastify/fastify-rate-limit/blob/843aca32546b2316e43e888064c9c94ebb1dafd9/types/index.d.ts#L49C5-L49C15

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
