### PR TITLE
feat: remove requirement to await fastify for auto instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,26 @@ app.register((instance, opts, done) => {
 }, { prefix: '/nested' })
 ```
 
-### Automatic plugin registration
+### Registration using OpenTelemetry Node SDK
 
-The plugin can be automatically registered with `registerOnInitialization` option set to `true`.
-In this case, it is necessary to await fastify instance.
+The plugin can be automatically registered using Node SDK, with `registerOnInitialization` option set to `true`.
 
 ```js
 // ... in your OTEL setup
-const fastifyOtelInstrumentation = new FastifyOtelInstrumentation({
-  registerOnInitialization: true,
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import FastifyOtelInstrumentation from "@fastify/otel";
+
+const sdk = new NodeSDK({
+  resource: ...,
+  traceExporter: ...,
+  instrumentations: [
+    ...others,
+    new FastifyOtelInstrumentation({ registerOnInitialization: true })
+  ],
 });
 
-// ... in your Fastify definition
-const Fastify = require('fastify');
-const app = await fastify();
+sdk.start();
+
 ```
 
 > **Notes**:

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -1,23 +1,77 @@
 const { default: fastify } = require('fastify')
-const { test, after, describe } = require('node:test')
+const { test, after, describe, beforeEach } = require('node:test')
 const { resourceFromAttributes } = require('@opentelemetry/resources')
 const { NodeSDK } = require('@opentelemetry/sdk-node')
 const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions')
 const FastifyOtelInstrumentation = require('..')
 const { ExportResultCode } = require('@opentelemetry/core')
 const assert = require('node:assert')
+const { trace } = require('@opentelemetry/api')
 
 describe('FastifyOtelInstrumentation with opentelemetry.NodeSDK', () => {
-  test('should export correct spans', async () => {
-    const traceExporter = {
-      spans: [],
-      export: (spans, resultCallback) => {
-        traceExporter.spans.push(...spans)
-        resultCallback({ code: ExportResultCode.SUCCESS })
-      },
-      shutdown: async () => {},
+  const traceExporter = {
+    spans: [],
+    export: (spans, resultCallback) => {
+      traceExporter.spans.push(...spans)
+      resultCallback({ code: ExportResultCode.SUCCESS })
+    },
+    shutdown: async () => {},
+    reset: () => {
+      traceExporter.spans = []
     }
+  }
 
+  beforeEach(() => {
+    trace.disable() // This is somehow necessary to reset Node SDK
+    traceExporter.reset()
+  })
+
+  test('should export spans when registered as a NodeSDK instrumentation', async () => {
+    const fastifyOtel = new FastifyOtelInstrumentation({ registerOnInitialization: true })
+    const sdk = new NodeSDK({
+      resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test-service' }),
+      traceExporter,
+      instrumentations: [fastifyOtel]
+    })
+    sdk.start()
+    after(() => sdk.shutdown())
+    after(() => fastifyOtel.disable())
+
+    const app = fastify()
+    app.get('/qq', async () => 'hello world')
+
+    await app.listen()
+    after(() => app.close())
+
+    const response = await fetch(
+      `http://localhost:${app.server.address().port}/qq`
+    )
+    assert.equal(response.status, 200)
+
+    await sdk.shutdown() // flush spans
+
+    const spans = traceExporter.spans
+    assert.equal(spans.length, 2)
+
+    assert.deepStrictEqual(spans[0].name, 'handler - fastify -> @fastify/otel')
+    assert.deepStrictEqual(spans[0].attributes, {
+      'fastify.type': 'request-handler',
+      'hook.callback.name': 'anonymous',
+      'hook.name': 'fastify - route-handler',
+      'http.route': '/qq',
+      'service.name': 'fastify',
+    })
+    assert.deepStrictEqual(spans[1].name, 'request')
+    assert.deepStrictEqual(spans[1].attributes, {
+      'fastify.root': '@fastify/otel',
+      'http.request.method': 'GET',
+      'http.response.status_code': 200,
+      'http.route': '/qq',
+      'service.name': 'fastify',
+    })
+  })
+
+  test('should export spans when registered as Fastify plugin', async () => {
     const sdk = new NodeSDK({
       resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'test-service' }),
       traceExporter,


### PR DESCRIPTION
Previously "registerOnInitialization: true" requires user code to await fastify first, which is error-prone and not very automatic. This commit eliminate the requirement so instrumentation can be done without changing app code.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
