### PR TITLE
chore: update to @opentelemetry/instrumentation 0.205.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@fastify/type-provider-typebox": "^5.0.0-pre.fv5.1",
     "@opentelemetry/context-async-hooks": "^2.0.0",
     "@opentelemetry/contrib-test-utils": "^0.49.0",
-    "@opentelemetry/instrumentation-http": "^0.203.0",
+    "@opentelemetry/instrumentation-http": "^0.205.0",
     "@opentelemetry/propagator-jaeger": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^1.29.0",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.203.0",
+    "@opentelemetry/instrumentation": "^0.205.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
     "minimatch": "^10.0.3"
   },


### PR DESCRIPTION
Upgrade to the latest OTel JS experimental (0.205.0). This is needed to avoid multiple copies of `@opentelemetry/instrumentation` package when updating to latest OTel.



Appreciated if a release could be made after the upgrade :pray: 