### PR TITLE
Update requestHook example for latest Fastify api

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ const otel = new FastifyOtelInstrumentation({
     span.setAttribute('user.id', request.headers['x-user-id'] ?? 'anonymous')
 
     // optional: give the span a cleaner name
-    span.updateName(`${request.method} ${request.routerPath}`)
+    span.updateName(`${request.method} ${request.routeOptions.url}`)
   }
 })
 ```


### PR DESCRIPTION
The `request.routerPath` was accurate in Fastify v0.3, but was deprecated in v0.4 and removed in v0.5.
