### PR TITLE
feat: Use http.route attribute in line with otel spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const { getRPCMetadata, RPCType } = require('@opentelemetry/core')
 const {
   ATTR_HTTP_ROUTE,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
-  ATTR_HTTP_REQUEST_METHOD
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_URL_PATH
 } = require('@opentelemetry/semantic-conventions')
 const { InstrumentationBase } = require('@opentelemetry/instrumentation')
 
@@ -271,13 +272,19 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
           rpcMetadata.route = request.routeOptions.url
         }
 
+        const attributes = {
+          [ATTRIBUTE_NAMES.ROOT]: '@fastify/otel',
+          [ATTR_HTTP_REQUEST_METHOD]: request.method,
+          [ATTR_URL_PATH]: request.url
+        }
+
+        if (request.routeOptions.url != null) {
+          attributes[ATTR_HTTP_ROUTE] = request.routeOptions.url
+        }
+
         /** @type {import('@opentelemetry/api').Span} */
         const span = this[kInstrumentation].tracer.startSpan('request', {
-          attributes: {
-            [ATTRIBUTE_NAMES.ROOT]: '@fastify/otel',
-            [ATTR_HTTP_ROUTE]: request.url,
-            [ATTR_HTTP_REQUEST_METHOD]: request.method
-          }
+          attributes
         }, ctx)
 
         try {

--- a/test/env-vars.test.js
+++ b/test/env-vars.test.js
@@ -83,6 +83,7 @@ describe('Environment variable aware FastifyInstrumentation', () => {
       assert.deepStrictEqual(start.attributes, {
         'fastify.root': '@fastify/otel',
         'http.route': '/',
+        'url.path': '/',
         'http.request.method': 'GET',
         'http.response.status_code': 200
       })

--- a/test/sdk.test.js
+++ b/test/sdk.test.js
@@ -66,6 +66,7 @@ describe('FastifyOtelInstrumentation with opentelemetry.NodeSDK', () => {
       'http.request.method': 'GET',
       'http.response.status_code': 200,
       'http.route': '/qq',
+      'url.path': '/qq',
     })
   })
 
@@ -107,6 +108,7 @@ describe('FastifyOtelInstrumentation with opentelemetry.NodeSDK', () => {
       'http.request.method': 'GET',
       'http.response.status_code': 200,
       'http.route': '/qq',
+      'url.path': '/qq',
     })
   })
 })


### PR DESCRIPTION
This commit renames the existing `http.route` to `url.path`, and then sets `http.route` only when the value is available from routeOptions.

The [OTel semantic conventions for HTTP server spans][1] state that `http.route`:

> MUST NOT be populated when this is not supported by the HTTP server
> framework as the route attribute should have low-cardinality and the
> URI path can NOT substitute it. SHOULD include the application root if
> there is one.

When using a parameterized route, such as /users/:userId, that means the value of the `http.route` attribute should be "/users/:userId" and not, for example, "/users/123". The spec instead suggests the attribute `url.path` for that value.

[1]: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)