### PR TITLE
chore: update to @opentelemetry/instrumentation 0.207.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.205.0",
+    "@opentelemetry/instrumentation": "^0.207.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
     "minimatch": "^10.0.3"
   },


### PR DESCRIPTION
Upgrade to the latest OTel JS experimental (0.207.0). This is needed to avoid multiple copies of @opentelemetry/instrumentation package when updating to latest OTel.

Appreciated if a release could be made after the upgrade 🙏

(PR description shamelessly copied from #92) 