### PR TITLE
feat: add lifecycleHook customization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,28 @@ const otel = new FastifyOtelInstrumentation({
 })
 ```
 
+#### `FastifyOtelInstrumentationOptions#lifecycleHook: function`
+
+A **synchronous** callback that runs whenever a span is created for a Fastify lifecycle hook (route hooks, instance hooks, not-found handlers, and route handlers).
+* **span** – the hook span that was just created
+* **info.hookName** – Fastify lifecycle stage (e.g., `onRequest`, `preHandler`, `handler`)
+* **info.handler** – the resolved handler or plugin name when available
+* **info.request** – the current `FastifyRequest`
+
+Use it to rename hook spans or annotate them with framework-specific metadata (for example, tRPC procedure names) without registering additional Fastify hooks.
+
+```js
+const otel = new FastifyOtelInstrumentation({
+  lifecycleHook: (span, info) => {
+    if (info.hookName === 'handler' && info.request.headers['x-trpc-op'] != null) {
+      span.updateName(`tRPC handler - ${info.request.headers['x-trpc-op']}`)
+    }
+
+    span.setAttribute('hook.handler.name', info.handler ?? 'anonymous')
+  }
+})
+```
+
 ## License
 
 Licensed under [MIT](./LICENSE).

--- a/index.js
+++ b/index.js
@@ -481,7 +481,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
                 handler: handlerName
               })
             } catch (err) {
-              instrumentation.logger.error({ err }, 'lifecycleHook threw')
+              instrumentation.logger.error({ err }, 'Execution of lifecycleHook failed')
             }
           }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ import type { FastifyPluginCallback } from 'fastify'
 
 import type {
   FastifyOtelInstrumentationOpts,
+  FastifyOtelLifecycleHookInfo,
   FastifyOtelOptions,
   FastifyOtelRequestContext
 } from './types'
@@ -27,7 +28,7 @@ declare class FastifyOtelInstrumentation<Config extends FastifyOtelInstrumentati
 }
 
 declare namespace exported {
-  export type { FastifyOtelInstrumentationOpts }
+  export type { FastifyOtelInstrumentationOpts, FastifyOtelLifecycleHookInfo }
   export { FastifyOtelInstrumentation }
   export { FastifyOtelInstrumentation as default }
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -13,6 +13,12 @@ expectAssignable<InstrumentationConfig>({
   requestHook (span, request) {
     expectAssignable<Span>(span)
     expectAssignable<FastifyRequest>(request)
+  },
+  lifecycleHook (span, info) {
+    expectAssignable<Span>(span)
+    expectAssignable<string>(info.hookName)
+    expectAssignable<FastifyRequest>(info.request)
+    expectAssignable<string | undefined>(info.handler)
   }
 } as FastifyOtelInstrumentationOpts)
 expectAssignable<InstrumentationConfig>({} as FastifyOtelInstrumentationOpts)

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -8,6 +8,13 @@ export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
   registerOnInitialization?: boolean
   ignorePaths?: string | ((routeOpts: { url: string, method: HTTPMethods }) => boolean);
   requestHook?: (span: import('@opentelemetry/api').Span, request: import('fastify').FastifyRequest) => void
+  lifecycleHook?: (span: import('@opentelemetry/api').Span, info: FastifyOtelLifecycleHookInfo) => void
+}
+
+export interface FastifyOtelLifecycleHookInfo {
+  hookName: string
+  request: import('fastify').FastifyRequest
+  handler?: string
 }
 
 interface FastifyOtelRequestInfo {


### PR DESCRIPTION
Closes #106  
## Summary
- add a `lifecycleHook` option to `FastifyOtelInstrumentation` so users can rename/annotate every Fastify lifecycle span
- expose the new type definitions and document the option
- cover the feature with unit + tsd tests

## Testing
- npm test

## Checklist

- [x]  run npm run test && npm run benchmark --if-present (benchmarks not present)
- [x]  tests and/or benchmarks are included
- [x]  documentation is changed or added
- [x]  commit message and code follows the Developer’s Certificate of Origin and Code of Conduct