### PR TITLE
feat: make span exception recording optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ const otel = new FastifyOtelInstrumentation({
 })
 ```
 
+#### `FastifyOtelInstrumentationOptions#recordExceptions: boolean`
+
+Control whether the instrumentation automatically calls `span.recordException` when a handler or hook throws.
+Defaults to `true`, recording every exception. Set it to `false` if you prefer to record only the
+exceptions that you consider actionable (for example to avoid noisy `4xx` entries in Datadog Error Tracking).
+
 ## License
 
 Licensed under [MIT](./LICENSE).

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -19,7 +19,8 @@ expectAssignable<InstrumentationConfig>({
     expectAssignable<string>(info.hookName)
     expectAssignable<FastifyRequest>(info.request)
     expectAssignable<string | undefined>(info.handler)
-  }
+  },
+  recordExceptions: false
 } as FastifyOtelInstrumentationOpts)
 expectAssignable<InstrumentationConfig>({} as FastifyOtelInstrumentationOpts)
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -9,6 +9,7 @@ export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
   ignorePaths?: string | ((routeOpts: { url: string, method: HTTPMethods }) => boolean);
   requestHook?: (span: import('@opentelemetry/api').Span, request: import('fastify').FastifyRequest) => void
   lifecycleHook?: (span: import('@opentelemetry/api').Span, info: FastifyOtelLifecycleHookInfo) => void
+  recordExceptions?: boolean
 }
 
 export interface FastifyOtelLifecycleHookInfo {


### PR DESCRIPTION
## Summary
- add a validated `recordExceptions` option that defaults to the current behavior
- gate every span.recordException call on that flag while still marking spans as errors
- document the option and cover it in both JS and TS test suites

## Testing
- npm run test:unit

Fixes #91