### PR TITLE
fix: remove setStatus(OK) calls to comply with OTel spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,12 +320,8 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         const span = request[kRequestSpan]
 
         if (span != null) {
-          span.setStatus({
-            code: SpanStatusCode.OK,
-            message: 'OK'
-          })
           span.setAttributes({
-            [ATTR_HTTP_RESPONSE_STATUS_CODE]: 404
+            [ATTR_HTTP_RESPONSE_STATUS_CODE]: reply.statusCode
           })
           span.end()
         }
@@ -345,11 +341,8 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         const span = request[kRequestSpan]
 
         if (span != null) {
-          if (reply.statusCode < 500) {
-            span.setStatus({
-              code: SpanStatusCode.OK,
-              message: 'OK'
-            })
+          if (reply.statusCode >= 500) {
+            span.setStatus({ code: SpanStatusCode.ERROR })
           }
 
           span.setAttributes({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -336,6 +336,8 @@ describe('FastifyInstrumentation', () => {
         'http.response.status_code': 200
       })
 
+      assert.equal(start.status.code, SpanStatusCode.UNSET)
+
       assert.equal(end.name, 'handler - fastify -> @fastify/otel')
       assert.deepStrictEqual(end.attributes, {
         'hook.name': 'fastify -> @fastify/otel - route-handler',
@@ -757,6 +759,7 @@ describe('FastifyInstrumentation', () => {
         'hook.name': 'fastify -> @fastify/otel - preHandler'
       })
       assert.equal(preHandler.status.code, SpanStatusCode.ERROR)
+      assert.equal(start.status.code, SpanStatusCode.ERROR)
       assert.equal(preHandler.parentSpanContext.spanId, start.spanContext().spanId)
       assert.equal(response.status, 500)
     })
@@ -794,6 +797,7 @@ describe('FastifyInstrumentation', () => {
         'http.request.method': 'POST',
         'http.response.status_code': 404
       })
+      assert.equal(start.status.code, SpanStatusCode.UNSET)
     })
 
     test('should create named span (404 - customized)', async t => {
@@ -1101,6 +1105,7 @@ describe('FastifyInstrumentation', () => {
         'http.route': '/',
         'hook.callback.name': 'helloworld'
       })
+      assert.equal(start.status.code, SpanStatusCode.ERROR)
       assert.equal(end.parentSpanContext.spanId, start.spanContext().spanId)
       assert.equal(response.status, 500)
       assert.deepStrictEqual(await response.json(), {


### PR DESCRIPTION
Fixes #126

Remove `setStatus(OK)` calls from `finalizeResponseSpanHook` and `finalizeNotFoundSpanHook` to comply with the [OTel spec](https://opentelemetry.io/docs/specs/otel/trace/api/#set-status), which states instrumentation libraries should leave span status as `Unset` unless there is an error.

- Only set `SpanStatusCode.ERROR` for 5xx responses
- Use `reply.statusCode` instead of hardcoded `404` in `finalizeNotFoundSpanHook`

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)