### PR TITLE
chore: remove tsd config

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,5 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0"
-  },
-  "tsd": {
-    "directory": "types"
   }
 }


### PR DESCRIPTION
Proposal:

- Remove the `tsd` configuration from the `package.json` file, since we use `tstyche` for type testing 