### PR TITLE
fix: mark request spans as server spans

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const dc = require('node:diagnostics_channel')
-const { context, trace, SpanStatusCode, propagation, diag } = require('@opentelemetry/api')
+const { context, trace, SpanKind, SpanStatusCode, propagation, diag } = require('@opentelemetry/api')
 const { getRPCMetadata, RPCType } = require('@opentelemetry/core')
 const {
   ATTR_HTTP_ROUTE,
@@ -298,7 +298,8 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
 
         /** @type {import('@opentelemetry/api').Span} */
         const span = this[kInstrumentation].tracer.startSpan('request', {
-          attributes
+          attributes,
+          kind: SpanKind.SERVER
         }, ctx)
 
         try {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,6 +23,7 @@ const {
 } = require('@opentelemetry/sdk-trace-base')
 const {
   context,
+  SpanKind,
   SpanStatusCode,
   trace,
   propagation
@@ -337,6 +338,7 @@ describe('FastifyInstrumentation', () => {
       })
 
       assert.equal(start.status.code, SpanStatusCode.UNSET)
+      assert.equal(start.kind, SpanKind.SERVER)
 
       assert.equal(end.name, 'handler - fastify -> @fastify/otel')
       assert.deepStrictEqual(end.attributes, {


### PR DESCRIPTION
## Summary
- mark the Fastify request span as `SpanKind.SERVER`
- add a regression assertion for the request span kind

Fixes #152

## Tests
- npm run lint
- npm test
