### PR TITLE
feat!: split instrumented | enabled OTEL context

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ For more information about OpenTelemetry, please refer to the [OpenTelemetry Jav
 
 The `FastifyOtelRequestContext` is a wrapper around the OpenTelemetry `Context` and `Tracer` APIs. It also provides a way to manage the context of a request and its associated spans as well as some utilities to extract and inject further traces from and to the trace carrier.
 
+#### `FastifyOtelRequestContext#enabled: boolean`
+Whether OpenTelemetry is enabled for the instrumentation and route configuration.
+
+#### `FastifyOtelRequestContext#instrumented: boolean`
+Whether the current request has an OpenTelemetry span and context. This can be `false`
+when instrumentation is enabled, but the request is intentionally skipped by options such
+as `ignorePaths`. Use it as a runtime signal before using request span APIs.
+
 #### `FastifyOtelRequestContext#context: Context`
 The OpenTelemetry context object.
 
@@ -143,7 +151,13 @@ const app = fastify();
 await app.register(fastifyOtelInstrumentation.plugin());
 
 app.get('/', (req, reply) => {
-  const { context, tracer, span, inject, extract } = req.opentelemetry();
+  const otel = req.opentelemetry();
+
+  if (!otel.instrumented || otel.span == null || otel.context == null) {
+    return 'hello world';
+  }
+
+  const { context, tracer, span, inject, extract } = otel;
 
   // Extract a parent span from the request headers
   const parentCxt = extract(req.headers);

--- a/index.js
+++ b/index.js
@@ -247,9 +247,13 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
       instance.decorateRequest('opentelemetry', function openetelemetry () {
         const ctx = this[kRequestContext]
         const span = this[kRequestSpan]
+        const enabled = instrumentation.isEnabled() &&
+          !isRouteOtelDisabled(this.routeOptions.config)
+        const instrumented = span != null && ctx != null
 
         return {
-          enabled: !isRouteOtelDisabled(this.routeOptions.config),
+          enabled,
+          instrumented,
           span,
           tracer: instrumentation.tracer,
           context: ctx,

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -288,6 +288,40 @@ describe('Interface', () => {
     await app.close()
   })
 
+  test('FastifyRequest#opentelemetry() returns an enabled but uninstrumented context when the path is ignored by a function', async () => {
+    const app = Fastify()
+    const instrumentation = new FastifyInstrumentation({
+      ignorePaths: (opts) => opts.url === '/health'
+    })
+    const plugin = instrumentation.plugin()
+    let otel
+
+    await app.register(plugin)
+
+    app.get('/health', (request) => {
+      otel = request.opentelemetry()
+
+      return 'ok'
+    })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/health'
+    })
+
+    assert.equal(res.statusCode, 200)
+    assert.equal(res.payload, 'ok')
+    assert.equal(otel.enabled, true)
+    assert.equal(otel.instrumented, false)
+    assert.equal(otel.span, null)
+    assert.equal(typeof otel.tracer, 'object')
+    assert.equal(otel.context, null)
+    assert.equal(typeof otel.inject, 'function')
+    assert.equal(typeof otel.extract, 'function')
+
+    await app.close()
+  })
+
   test('FastifyRequest#opentelemetry() returns an uninstrumented context when instrumentation is disabled', async () => {
     const app = Fastify()
     const instrumentation = new FastifyInstrumentation()

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -89,6 +89,7 @@ describe('Interface', () => {
       const otel = request.opentelemetry()
 
       assert.equal(otel.enabled, true)
+      assert.equal(otel.instrumented, true)
       assert.equal(typeof otel.span.spanContext().spanId, 'string')
       assert.equal(typeof otel.tracer, 'object')
       assert.equal(typeof otel.context, 'object')
@@ -109,7 +110,7 @@ describe('Interface', () => {
     assert.equal(res.payload, 'world')
   })
 
-  test('FastifyRequest#opentelemetry() returns FastifyDisabledOtelRequestContext when disabled for a request', async () => {
+  test('FastifyRequest#opentelemetry() returns an uninstrumented context when disabled for a request', async () => {
     /** @type {import('fastify').FastifyInstance} */
     const app = Fastify()
     const instrumentation = new FastifyInstrumentation()
@@ -121,6 +122,7 @@ describe('Interface', () => {
       const otel = request.opentelemetry()
 
       assert.equal(otel.enabled, false)
+      assert.equal(otel.instrumented, false)
       assert.equal(otel.span, null)
       assert.equal(typeof otel.tracer, 'object')
       assert.equal(otel.context, null)
@@ -138,6 +140,7 @@ describe('Interface', () => {
       const otel = request.opentelemetry()
 
       assert.equal(otel.enabled, true)
+      assert.equal(otel.instrumented, true)
       assert.equal(typeof otel.span.spanContext().spanId, 'string')
       assert.equal(typeof otel.tracer, 'object')
       assert.equal(typeof otel.context, 'object')
@@ -156,6 +159,7 @@ describe('Interface', () => {
 
       assert.equal(request.fakeData, 123)
       assert.equal(otel.enabled, false)
+      assert.equal(otel.instrumented, false)
       assert.equal(otel.span, null)
       assert.equal(typeof otel.tracer, 'object')
       assert.equal(otel.context, null)
@@ -189,6 +193,7 @@ describe('Interface', () => {
         const otel = request.opentelemetry()
 
         assert.equal(otel.enabled, false)
+        assert.equal(otel.instrumented, false)
         assert.equal(otel.span, null)
         assert.equal(typeof otel.tracer, 'object')
         assert.equal(otel.context, null)
@@ -236,6 +241,7 @@ describe('Interface', () => {
       const otel = request.opentelemetry()
 
       assert.equal(otel.enabled, true)
+      assert.equal(otel.instrumented, true)
       assert.equal(typeof otel.span.spanContext().spanId, 'string')
       assert.equal(typeof otel.context, 'object')
 
@@ -248,6 +254,70 @@ describe('Interface', () => {
     })
     assert.equal(res.statusCode, 200)
     assert.equal(res.payload, 'ok')
+  })
+
+  test('FastifyRequest#opentelemetry() returns an enabled but uninstrumented context when the path is ignored', async () => {
+    const app = Fastify()
+    const instrumentation = new FastifyInstrumentation({
+      ignorePaths: '/health'
+    })
+    const plugin = instrumentation.plugin()
+    let otel
+
+    await app.register(plugin)
+
+    app.get('/health', (request) => {
+      otel = request.opentelemetry()
+
+      return 'ok'
+    })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/health'
+    })
+
+    assert.equal(res.statusCode, 200)
+    assert.equal(res.payload, 'ok')
+    assert.equal(otel.enabled, true)
+    assert.equal(otel.instrumented, false)
+    assert.equal(otel.span, null)
+    assert.equal(typeof otel.tracer, 'object')
+    assert.equal(otel.context, null)
+
+    await app.close()
+  })
+
+  test('FastifyRequest#opentelemetry() returns an uninstrumented context when instrumentation is disabled', async () => {
+    const app = Fastify()
+    const instrumentation = new FastifyInstrumentation()
+    const plugin = instrumentation.plugin()
+    let otel
+
+    await app.register(plugin)
+
+    app.get('/disabled', (request) => {
+      otel = request.opentelemetry()
+
+      return 'ok'
+    })
+
+    instrumentation.disable()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/disabled'
+    })
+
+    assert.equal(res.statusCode, 200)
+    assert.equal(res.payload, 'ok')
+    assert.equal(otel.enabled, false)
+    assert.equal(otel.instrumented, false)
+    assert.equal(otel.span, null)
+    assert.equal(typeof otel.tracer, 'object')
+    assert.equal(otel.context, null)
+
+    await app.close()
   })
 
   test('FastifyInstrumentation#requestHook should be invoked and can mutate span', async () => {

--- a/test/env-vars.test.js
+++ b/test/env-vars.test.js
@@ -103,10 +103,15 @@ describe('Environment variable aware FastifyInstrumentation', () => {
 
       const app = Fastify()
       const plugin = instrumentation.plugin()
+      let otel
 
       await app.register(plugin)
 
-      app.get('/health/up', async (request, reply) => 'hello world')
+      app.get('/health/up', async (request, reply) => {
+        otel = request.opentelemetry()
+
+        return 'hello world'
+      })
 
       await app.listen()
 
@@ -121,6 +126,10 @@ describe('Environment variable aware FastifyInstrumentation', () => {
         .filter(span => span.instrumentationLibrary.name === '@fastify/otel')
 
       assert.equal(spans.length, 0)
+      assert.equal(otel.enabled, true)
+      assert.equal(otel.instrumented, false)
+      assert.equal(otel.span, null)
+      assert.equal(otel.context, null)
       assert.equal(await response.text(), 'hello world')
       assert.equal(response.status, 200)
     })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,7 @@ declare namespace exported {
     FastifyOtelHookName,
     FastifyOtelInstrumentationOpts,
     FastifyOtelLifecycleHookInfo,
+    FastifyOtelRequestContext,
     FastifyOtelRouteConfig
   }
   export { FastifyOtelInstrumentation }

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -57,6 +57,7 @@ app.get('/', async function (request, reply) {
     (carrier: any, getter?: TextMapGetter) => Context
 >().type.toBeAssignableTo<(carrier: any, getter?: TextMapGetter) => Context>()
   expect(otel.tracer).type.toBeAssignableTo<Tracer>()
+  expect(otel.instrumented).type.toBeAssignableTo<boolean>()
 
   if (otel.enabled) {
     expect(otel.span).type.toBeAssignableTo<Span>()

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -34,6 +34,7 @@ export interface FastifyOtelLifecycleHookInfo {
 }
 
 interface FastifyOtelRequestInfo {
+  instrumented: boolean,
   tracer: Tracer,
   inject: (carrier: {}, setter?: TextMapSetter) => void;
   extract: (carrier: {}, getter?: TextMapGetter) => Context


### PR DESCRIPTION
Issue Link: https://github.com/fastify/otel/issues/170 



feat: expose instrumented request context state

Core change:
- restore enabled to application/route-level meaning
- add instrumented: span != null && context != null
- use instrumented as the TS discriminator
- update tests for ignorePaths / disabled / otel false


```
enabled
= otel is enabled by global/route config

instrumented
= this specific request actually has span/context
```




<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
