### PR TITLE
fix: use INTERNAL kind for request span under an upstream http instrumentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,9 +399,16 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         }
 
         /** @type {import('@opentelemetry/api').Span} */
+        // When an upstream HTTP server instrumentation is active (e.g.
+        // @opentelemetry/instrumentation-http via auto-instrumentations-node),
+        // the incoming request already has a SERVER span and RPC metadata in
+        // the active context. Creating a second SERVER span for the same
+        // request breaks span-kind semantics and makes backends that map
+        // SERVER spans to transactions report the request twice. In that case
+        // the request span is INTERNAL; standalone usage keeps SERVER.
         const span = this[kInstrumentation].tracer.startSpan('request', {
           attributes,
-          kind: SpanKind.SERVER
+          kind: rpcMetadata?.type === RPCType.HTTP ? SpanKind.INTERNAL : SpanKind.SERVER
         }, ctx)
 
         try {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -338,7 +338,9 @@ describe('FastifyInstrumentation', () => {
       })
 
       assert.equal(start.status.code, SpanStatusCode.UNSET)
-      assert.equal(start.kind, SpanKind.SERVER)
+      // http instrumentation is enabled in this suite, so the request span is
+      // demoted to INTERNAL (the SERVER span belongs to instrumentation-http)
+      assert.equal(start.kind, SpanKind.INTERNAL)
 
       assert.equal(end.name, 'handler - fastify -> @fastify/otel')
       assert.deepStrictEqual(end.attributes, {
@@ -347,6 +349,39 @@ describe('FastifyInstrumentation', () => {
         'http.route': '/',
         'hook.callback.name': 'anonymous'
       })
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'hello world')
+    })
+
+    test('should keep SERVER kind when no upstream http instrumentation is active', async t => {
+      // Without @opentelemetry/instrumentation-http there is no RPC metadata
+      // in the active context, so the request span is the root server span.
+      httpInstrumentation.disable()
+
+      const app = Fastify()
+      const plugin = instrumentation.plugin()
+
+      await app.register(plugin)
+
+      app.get('/', async (request, reply) => 'hello world')
+
+      await app.listen()
+
+      after(() => app.close())
+
+      const response = await fetch(
+        `http://localhost:${app.server.address().port}/`
+      )
+
+      const spans = memoryExporter
+        .getFinishedSpans()
+        .filter(span => span.instrumentationScope.name === '@fastify/otel')
+
+      const [, start] = spans
+
+      assert.equal(spans.length, 2)
+      assert.equal(start.name, 'request')
+      assert.equal(start.kind, SpanKind.SERVER)
       assert.equal(response.status, 200)
       assert.equal(await response.text(), 'hello world')
     })
@@ -412,6 +447,8 @@ describe('FastifyInstrumentation', () => {
         'http.route': '/',
         'hook.callback.name': 'helloworld'
       })
+      assert.equal(start.kind, SpanKind.INTERNAL)
+      assert.equal(httpSpan.kind, SpanKind.SERVER)
       assert.equal(end.parentSpanContext.spanId, start.spanContext().spanId)
       assert.equal(start.parentSpanContext.spanId, httpSpan.spanContext().spanId)
       assert.equal(httpSpan.parentSpanContext.spanId, span.spanContext().spanId)


### PR DESCRIPTION
## Summary

- When `FastifyOtelInstrumentation` runs alongside `@opentelemetry/instrumentation-http` (the default with `auto-instrumentations-node` / the OpenTelemetry Operator nodejs image), each request produced **two nested SERVER spans** in the same service — backends that map SERVER spans to transactions (e.g. Elastic APM) report every request twice, the duplicate always named `request`.
- Use the already-computed `rpcMetadata` to pick the span kind: `INTERNAL` when an upstream HTTP server instrumentation is active in the context, `SERVER` otherwise — the standalone behaviour from #156 / #152 is preserved.

Fixes #172

## Tests

- updated the existing kind assertion (that suite runs with `HttpInstrumentation` enabled, so the request span is now INTERNAL there) and asserted `httpSpan` stays SERVER in the propagation test
- added a regression test for the standalone case (http instrumentation disabled → request span stays SERVER)
- `npm run test:v4` + `test:v5`: 62/62 pass, c8 coverage stays 100%
- `npm run lint`, `npm run test:typescript`: clean