### PR TITLE
fix: support array hooks in setNotFoundHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -500,6 +500,14 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         }
       }
 
+      function wrapNotFoundHookHandler (handlerLike, hookName, getSpanAttributes) {
+        if (Array.isArray(handlerLike)) {
+          return handlerLike.map(handler => handlerWrapper(handler, hookName, getSpanAttributes(handler)))
+        }
+
+        return handlerWrapper(handlerLike, hookName, getSpanAttributes(handlerLike))
+      }
+
       function setNotFoundHandlerPatched (hooks, handler) {
         const setNotFoundHandlerOriginal = this[kSetNotFoundOriginal]
         if (typeof hooks === 'function') {
@@ -519,28 +527,28 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
             hooks.preValidation != null &&
             shouldInstrumentLifecycleHook('preValidation', globalHookPolicy)
           ) {
-            hooks.preValidation = handlerWrapper(hooks.preValidation, 'notFoundHandler - preValidation', {
+            hooks.preValidation = wrapNotFoundHookHandler(hooks.preValidation, 'notFoundHandler - preValidation', handler => ({
               [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - not-found-handler - preValidation`,
               [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.INSTANCE,
               [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]:
-                hooks.preValidation.name?.length > 0
-                  ? hooks.preValidation.name
+                handler.name?.length > 0
+                  ? handler.name
                   : ANONYMOUS_FUNCTION_NAME /* c8 ignore next */
-            })
+            }))
           }
 
           if (
             hooks.preHandler != null &&
             shouldInstrumentLifecycleHook('preHandler', globalHookPolicy)
           ) {
-            hooks.preHandler = handlerWrapper(hooks.preHandler, 'notFoundHandler - preHandler', {
+            hooks.preHandler = wrapNotFoundHookHandler(hooks.preHandler, 'notFoundHandler - preHandler', handler => ({
               [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - not-found-handler - preHandler`,
               [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.INSTANCE,
               [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]:
-                hooks.preHandler.name?.length > 0
-                  ? hooks.preHandler.name
+                handler.name?.length > 0
+                  ? handler.name
                   : ANONYMOUS_FUNCTION_NAME /* c8 ignore next */
-            })
+            }))
           }
 
           handler = handlerWrapper(handler, 'notFoundHandler', {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1262,6 +1262,62 @@ describe('FastifyInstrumentation', () => {
       assert.equal(preHandler.parentSpanContext.spanId, start.spanContext().spanId)
     })
 
+    test('should create named spans for 404 hooks declared as arrays', async t => {
+      const app = Fastify()
+      const plugin = instrumentation.plugin()
+
+      await app.register(plugin)
+
+      app.setNotFoundHandler(
+        {
+          preHandler: [
+            function preHandlerOne (request, reply, done) {
+              done()
+            },
+            function preHandlerTwo (request, reply, done) {
+              done()
+            }
+          ],
+          preValidation: [
+            function preValidationOne (request, reply, done) {
+              done()
+            },
+            function preValidationTwo (request, reply, done) {
+              done()
+            }
+          ]
+        },
+        async function notFoundHandler (request, reply) {
+          reply.code(200).send('missing')
+        }
+      )
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/missing'
+      })
+
+      const spans = memoryExporter
+        .getFinishedSpans()
+        .filter(span => span.instrumentationScope.name === '@fastify/otel')
+
+      const hookCallbackNames = spans
+        .map(span => span.attributes['hook.callback.name'])
+        .filter(Boolean)
+        .sort()
+
+      assert.equal(response.statusCode, 200)
+      assert.equal(response.body, 'missing')
+      assert.equal(spans.length, 6)
+      assert.deepStrictEqual(hookCallbackNames, [
+        'notFoundHandler',
+        'preHandlerOne',
+        'preHandlerTwo',
+        'preValidationOne',
+        'preValidationTwo'
+      ])
+    })
+
     test('should create span when the handler is overriden', async t => {
       const app = Fastify()
       const plugin = instrumentation.plugin()


### PR DESCRIPTION
## Summary

- Support array values for `setNotFoundHandler` `preValidation` and `preHandler` hooks.
- Wrap each hook individually so Fastify receives callable handlers.
- Preserve callback names for each generated hook span.
- Add regression coverage for custom 404 handlers using hook arrays.

## Root cause

The not-found handler patch passed the entire hook array to `handlerWrapper()`. The wrapper later called `handler.call(...)`, causing `handler.call is not a function` and a 500 response.

## Verification

- `npm test`
- `npm run lint`