### PR TITLE
fix: preserve the error description on the request span for 5xx

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ const ANONYMOUS_FUNCTION_NAME = 'anonymous'
 const kInstrumentation = Symbol('fastify otel instance')
 const kRequestSpan = Symbol('fastify otel request spans')
 const kRequestContext = Symbol('fastify otel request context')
+const kErrorStatusSet = Symbol('fastify otel error status set')
 const kAddHookOriginal = Symbol('fastify otel addhook original')
 const kSetNotFoundOriginal = Symbol('fastify otel setnotfound original')
 const kIgnorePaths = Symbol('fastify otel ignore path')
@@ -284,6 +285,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
       })
       instance.decorateRequest(kRequestSpan, null)
       instance.decorateRequest(kRequestContext, null)
+      instance.decorateRequest(kErrorStatusSet, false)
 
       instance.addHook('onRoute', function otelWireRoute (routeOptions) {
         if (instrumentation[kIgnorePaths]?.(routeOptions) === true) {
@@ -460,6 +462,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         }
 
         request[kRequestSpan] = null
+        request[kErrorStatusSet] = false
 
         hookDone()
       })
@@ -474,7 +477,11 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         const span = request[kRequestSpan]
 
         if (span != null) {
-          if (reply.statusCode >= 500) {
+          // setStatus replaces the status, so setting a bare ERROR here would
+          // drop the description recorded by recordErrorInSpanHook. A 5xx that
+          // never threw (e.g. reply.code(500).send()) has no description of its
+          // own, so it still needs the bare status.
+          if (reply.statusCode >= 500 && request[kErrorStatusSet] === false) {
             span.setStatus({ code: SpanStatusCode.ERROR })
           }
 
@@ -485,6 +492,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
         }
 
         request[kRequestSpan] = null
+        request[kErrorStatusSet] = false
 
         hookDone(null, payload)
       }
@@ -498,6 +506,7 @@ class FastifyOtelInstrumentation extends InstrumentationBase {
             code: SpanStatusCode.ERROR,
             message: error.message
           })
+          request[kErrorStatusSet] = true
           if (instrumentation[kRecordExceptions] !== false) {
             span.recordException(error)
           }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1151,6 +1151,104 @@ describe('FastifyInstrumentation', () => {
       assert.equal(response.status, 500)
     })
 
+    test('should keep the error description on the request span (5xx)', async t => {
+      const app = Fastify()
+      const plugin = instrumentation.plugin()
+
+      await app.register(plugin)
+
+      app.get('/', async function helloworld () {
+        throw new Error('kaboom')
+      })
+
+      await app.listen()
+
+      after(() => app.close())
+
+      const response = await fetch(
+        `http://localhost:${app.server.address().port}/`
+      )
+
+      const spans = memoryExporter
+        .getFinishedSpans()
+        .filter(span => span.instrumentationScope.name === '@fastify/otel')
+
+      const handler = spans.find(span => span.name.startsWith('handler'))
+      const start = spans.find(span => span.name === 'request')
+
+      assert.equal(spans.length, 2)
+      assert.equal(response.status, 500)
+      assert.deepStrictEqual(handler.status, {
+        code: SpanStatusCode.ERROR,
+        message: 'kaboom'
+      })
+      assert.deepStrictEqual(start.status, {
+        code: SpanStatusCode.ERROR,
+        message: 'kaboom'
+      })
+    })
+
+    test('should keep the error description on the request span (4xx)', async t => {
+      const app = Fastify()
+      const plugin = instrumentation.plugin()
+
+      await app.register(plugin)
+
+      app.get('/', async function helloworld () {
+        const error = new Error('kaboom')
+        error.statusCode = 400
+        throw error
+      })
+
+      await app.listen()
+
+      after(() => app.close())
+
+      const response = await fetch(
+        `http://localhost:${app.server.address().port}/`
+      )
+
+      const spans = memoryExporter
+        .getFinishedSpans()
+        .filter(span => span.instrumentationScope.name === '@fastify/otel')
+
+      const start = spans.find(span => span.name === 'request')
+
+      assert.equal(response.status, 400)
+      assert.deepStrictEqual(start.status, {
+        code: SpanStatusCode.ERROR,
+        message: 'kaboom'
+      })
+    })
+
+    test('should set an error status on a 5xx reply that did not throw', async t => {
+      const app = Fastify()
+      const plugin = instrumentation.plugin()
+
+      await app.register(plugin)
+
+      app.get('/', async function helloworld (request, reply) {
+        return reply.code(500).send('not an exception')
+      })
+
+      await app.listen()
+
+      after(() => app.close())
+
+      const response = await fetch(
+        `http://localhost:${app.server.address().port}/`
+      )
+
+      const spans = memoryExporter
+        .getFinishedSpans()
+        .filter(span => span.instrumentationScope.name === '@fastify/otel')
+
+      const start = spans.find(span => span.name === 'request')
+
+      assert.equal(response.status, 500)
+      assert.deepStrictEqual(start.status, { code: SpanStatusCode.ERROR })
+    })
+
     test('should create named span (404)', async t => {
       const app = Fastify()
       const plugin = instrumentation.plugin()


### PR DESCRIPTION
`recordErrorInSpanHook` (onError) records the error status with `error.message` as the description. `finalizeResponseSpanHook` (onSend) runs afterwards and, for `statusCode >= 500`, called `setStatus` again with no message. Per the OTel spec `setStatus` replaces the status, so the description was cleared immediately before `span.end()` and the root request span was exported as ERROR with an empty description.

Because the branch was gated on `>= 500`, 4xx kept its description and 5xx always lost it; child spans were unaffected.

Track whether the error hook already recorded a status and only apply the bare status when it did not, so a 5xx that never threw (e.g. `reply.code(500).send()`) still gets an error status.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
